### PR TITLE
Added docs about missing env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,16 @@ You can find more information about the purpose of each access flag at [DAO Regi
 Added the following environment variables to your local .env file:
 
 ```
-ETHERSCAN_API_KEY=
-TRUFFLE_MNEMONIC=. . . . . . . . . . . .
+# The Infura API Key is used to communicate with the Ethereum blockchain
 INFURA_KEY=
+# The mnemonic that generates you account
+TRUFFLE_MNEMONIC=orange apple banana ... 
+# Debug the Ether Scan contract verification calls
 DEBUG_CONTRACT_VERIFICATION=false
+# The Ether Scan API Key to verify the contracts after the deployment
+ETHERSCAN_API_KEY=
+# The public eth (0x...) address of the creator of the onboarding cupons
+COUPON_CREATOR_ADDR=
 ```
 
 ### Run Tests

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "deploy:ganache": "truffle deploy --network ganache --reset 2>&1 | tee ganache-deploy.log",
     "deploy:rinkeby": "truffle deploy --network rinkeby --reset 2>&1 | tee rinkeby-deploy.log",
     "deploy:mainnet": "truffle deploy --network mainnet --reset 2>&1 | tee mainnet-deploy.log",
-    "ganache": "ganache-cli --deterministic -p 8545 --networkId 1337",
+    "ganache": "ganache-cli --deterministic -p 7545 --networkId 1337",
     "lint": "prettier --list-different 'contracts/**/*.sol' '**/*.js' '**/*.md'",
     "lint:fix": "prettier --write 'contracts/**/*.sol' '**/*.js' '**/*.md'",
     "migrate": "truffle migrate --network",


### PR DESCRIPTION
The env var `COUPON_CREATOR_ADDR` must be defined when deploying to ganache, rinkeby or mainnet. I updated the env var section with that info, and fix the port number for the ganache task, it needs to match the port defined in the truffle-config, otherwise the `npm run ganache:deploy` command won't work.

Solves the issue flagged on ticket #277 