### PR TITLE
Can not join the dao with a 0x0 address

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ You can find more information about the purpose of each access flag at [DAO Regi
 Added the following environment variables to your local .env file:
 
 ```
+# The DAO Owner ETH Address (0x...) in the target network
+DAO_OWNER_ADDR=
 # The Infura API Key is used to communicate with the Ethereum blockchain
 INFURA_KEY=
 # The mnemonic that generates you account

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -211,6 +211,8 @@ contract DaoRegistry is MemberGuard, AdapterGuard {
         public
         hasAccess(this, AclFlag.NEW_MEMBER)
     {
+        require(memberAddress != address(0x0), "invalid member address");
+
         Member storage member = members[memberAddress];
         if (!getFlag(member.flags, uint8(MemberFlag.EXISTS))) {
             member.flags = setFlag(
@@ -539,8 +541,8 @@ contract DaoRegistry is MemberGuard, AdapterGuard {
      * @param addr The address to look up
      */
     function isMember(address addr) public view returns (bool) {
-        address memberAddr = memberAddressesByDelegatedKey[addr];
-        return getMemberFlag(memberAddr, MemberFlag.EXISTS);
+        address memberAddress = memberAddressesByDelegatedKey[addr];
+        return getMemberFlag(memberAddress, MemberFlag.EXISTS);
     }
 
     /**

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -13,15 +13,15 @@ const truffleImports = require("../utils/TruffleUtil.js");
 
 require("dotenv").config();
 
-module.exports = async (deployer, network) => {
+module.exports = async (deployer, network, accounts) => {
   let dao;
   const deployFunction = truffleImports.deployFunctionFactory(deployer);
   if (network === "ganache") {
-    dao = await deployGanacheDao(deployFunction, network);
+    dao = await deployGanacheDao(deployFunction, network, accounts);
   } else if (network === "rinkeby") {
     dao = await deployRinkebyDao(deployFunction, network);
   } else if (network === "test" || network === "coverage") {
-    dao = await deployTestDao(deployFunction, network);
+    dao = await deployTestDao(deployFunction, network, accounts);
   }
 
   if (dao) {
@@ -38,7 +38,7 @@ module.exports = async (deployer, network) => {
   }
 };
 
-async function deployTestDao(deployFunction, network) {
+async function deployTestDao(deployFunction, network, accounts) {
   let { dao } = await deployDao({
     ...truffleImports,
     deployFunction,
@@ -56,6 +56,7 @@ async function deployTestDao(deployFunction, network) {
     couponCreatorAddress: "0x7D8cad0bbD68deb352C33e80fccd4D8e88b4aBb8",
     offchainAdmin: "0xedC10CFA90A135C41538325DD57FDB4c7b88faf7",
     daoName: process.env.DAO_NAME,
+    owner: accounts[0],
   });
   return dao;
 }
@@ -77,12 +78,13 @@ async function deployRinkebyDao(deployFunction, network) {
     maxExternalTokens: 100,
     couponCreatorAddress: process.env.COUPON_CREATOR_ADDR,
     daoName: process.env.DAO_NAME,
+    owner: process.env.DAO_OWNER_ADDR,
     offchainAdmin: "0xedC10CFA90A135C41538325DD57FDB4c7b88faf7",
   });
   return dao;
 }
 
-async function deployGanacheDao(deployFunction, network) {
+async function deployGanacheDao(deployFunction, network, accounts) {
   let { dao } = await deployDao({
     ...truffleImports,
     deployFunction,
@@ -99,6 +101,7 @@ async function deployGanacheDao(deployFunction, network) {
     maxExternalTokens: 100,
     couponCreatorAddress: process.env.COUPON_CREATOR_ADDR,
     daoName: process.env.DAO_NAME,
+    owner: accounts[0],
     offchainAdmin: "0xedC10CFA90A135C41538325DD57FDB4c7b88faf7",
   });
   return dao;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tribute-contracts",
-  "version": "0.0.1",
+  "version": "1.0.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,15 @@
   "version": "1.0.0-rc2",
   "description": "A new modular DAO framework, inspired by the Moloch smart contracts",
   "main": "truffle-config.js",
-  "keywords": ["dao", "framework", "smart-contract", "solidity", "modular", "moloch", "ethereum"],
+  "keywords": [
+    "dao",
+    "framework",
+    "smart-contract",
+    "solidity",
+    "modular",
+    "moloch",
+    "ethereum"
+  ],
   "directories": {
     "test": "test"
   },

--- a/test/adapters/distribute.test.js
+++ b/test/adapters/distribute.test.js
@@ -53,6 +53,8 @@ const {
 const { onboardingNewMember } = require("../../utils/TestUtils.js");
 
 const daoOwner = accounts[2];
+const daoCreator = accounts[9];
+
 const proposalCounter = proposalIdGenerator().generator;
 
 function getProposalCounter() {
@@ -63,6 +65,7 @@ describe("Adapter - Distribute", () => {
   before("deploy dao", async () => {
     const { dao, adapters, extensions } = await deployDefaultDao({
       owner: daoOwner,
+      creator: daoCreator,
     });
     this.dao = dao;
     this.adapters = adapters;

--- a/test/core/registry.test.js
+++ b/test/core/registry.test.js
@@ -103,4 +103,12 @@ describe("Core - Registry", () => {
       "adapterId must not be empty"
     );
   });
+
+  it("should not be possible to a zero address be considered a member", async () => {
+    let registry = await DaoRegistry.new();
+    let isMember = await registry.isMember(
+      "0x0000000000000000000000000000000000000000"
+    );
+    expect(isMember).equal(false);
+  });
 });

--- a/test/core/registry.test.js
+++ b/test/core/registry.test.js
@@ -104,7 +104,7 @@ describe("Core - Registry", () => {
     );
   });
 
-  it("should not be possible to a zero address be considered a member", async () => {
+  it("should not be possible for a zero address to be considered a member", async () => {
     let registry = await DaoRegistry.new();
     let isMember = await registry.isMember(
       "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
It should not be possible to onboard a member using a 0x0 address.

Updated the deployment scripts to include the `owner` address in the `from` argument of the call, so it can be verified if the call was actually made by a member or not.

In addition to that, it updates the deployment script `2_deploy_contracts.js` to include the `owner` address in the dao creation -which is loaded from an environment variable `DAO_OWNER_ADDR` if the target network is Rinkeby. Othewise, for test and ganache deployments it uses the truffle accounts[0] as the `DAO_OWNER_ADDR`.

Fixes #282 