### PR TITLE
fix verification script

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -26,12 +26,17 @@ module.exports = async (deployer, network, accounts) => {
   let { dao, extensions } = res;
   if (dao) {
     await dao.finalizeDao();
-
     console.log("************************");
-    console.log(`DaoRegistry: ${dao.address}`);
-    console.log(`BankExtension: ${extensions.bank.address}`);
-    console.log(`NFTExtension: ${extensions.nft.address}`);
-    console.log(`ERC20Extension: ${extensions.erc20Ext.address}`);
+    console.log(`Cloned DaoRegistry: ${dao.address}`);
+    console.log(`Cloned BankExtension: ${extensions.bank.address}`);
+    console.log(
+      `Cloned NFTExtension: ${extensions.nft ? extensions.nft.address : ""}`
+    );
+    console.log(
+      `Cloned ERC20Extension: ${
+        extensions.erc20Ext ? extensions.erc20Ext.address : ""
+      }`
+    );
     console.log("************************");
   } else {
     console.log("************************");


### PR DESCRIPTION
This adds a new regex to capture the addresses of the deployed extensions, because the ones logged out on truffle logs are actually the identity extensions used to do the cloning. 
We need that only for the extension addresses, the adapter addresses and factory are correct.