### PR TITLE
Deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Added the following environment variables to your local .env file:
 - `ERC20_TOKEN_NAME`: The ERC20 Token Name used by the ERC20 Token Extension.
 - `ERC20_TOKEN_SYMBOL`: Token Symbol used by the ERC20 Token Extension.
 - `ERC20_TOKEN_DECIMALS`: The ERC20 Token Decimals to display in MetaMask.
+- `OFFCHAIN_ADMIN_ADDR`: The address of the admin account that manages the offchain voting adapter.
+- `VOTING_PERIOD_SECONDS`: The maximum amount of time in seconds that members are allowed vote on proposals.
+- `GRACE_PERIOD_SECONDS`: The minimum time in seconds after the voting period has ended, that the members need to wait before processing a proposal.
 
 Checkout the [sample .env file](https://github.com/openlawteam/tribute-contracts/.sample.env).
 
@@ -142,9 +145,11 @@ Checkout the [sample .env file](https://github.com/openlawteam/tribute-contracts
 
 - Ganache deployment: `DAO_NAME`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`, `COUPON_CREATOR_ADDR`.
 
+- Test deployment: `DAO_NAME`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`.
+
 - Rinkeby deployment: `DAO_NAME`, `DAO_OWNER_ADDR`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`, `COUPON_CREATOR_ADDR`.
 
-- Test deployment: `DAO_NAME`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`.
+- Mainnet deployment: `DAO_NAME`, `DAO_OWNER_ADDR`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`, `COUPON_CREATOR_ADDR`, `OFFCHAIN_ADMIN_ADDR`, `VOTING_PERIOD_SECONDS`, `GRACE_PERIOD_SECONDS`.
 
 ### Run Tests
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Added the following environment variables to your local .env file:
 - `OFFCHAIN_ADMIN_ADDR`: The address of the admin account that manages the offchain voting adapter.
 - `VOTING_PERIOD_SECONDS`: The maximum amount of time in seconds that members are allowed vote on proposals.
 - `GRACE_PERIOD_SECONDS`: The minimum time in seconds after the voting period has ended, that the members need to wait before processing a proposal.
+- `DAO_ARTIFACTS_OWNER_ADDR`: The owner address of the artifacts deployed. Leave it empty to if you want to use the `DAO_OWNER_ADDR` as the artifacts owner.
+- `DAO_ARTIFACTS_CONTRACT_ADDR`: The `DaoArtifacts` contract address that will be used in the deployment script to fetch Adapters and Factories during the deployment to save gas costs.
 
 Checkout the [sample .env file](https://github.com/openlawteam/tribute-contracts/.sample.env).
 

--- a/contracts/utils/DaoArtifacts.sol
+++ b/contracts/utils/DaoArtifacts.sol
@@ -52,7 +52,7 @@ contract DaoArtifacts {
      * @param _id The id of the adapter (sha3).
      * @param _version The version of the adapter.
      * @param _address The address of the adapter to be stored.
-     * @param _type The artifact type:  0 = Core, 1 = Factory, 2 = Extension, 3 = Adapter, 4 = Util.
+     * @param _type The artifact type: 0 = Core, 1 = Factory, 2 = Extension, 3 = Adapter, 4 = Util.
      */
     function addArtifact(
         bytes32 _id,
@@ -79,9 +79,6 @@ contract DaoArtifacts {
         bytes32 _version,
         ArtifactType _type
     ) external view returns (address) {
-        if (_type == ArtifactType.ADAPTER) {
-            return artifacts[_id][_owner][_type][_version];
-        }
-        return address(0x0);
+        return artifacts[_id][_owner][_type][_version];
     }
 }

--- a/contracts/utils/DaoArtifacts.sol
+++ b/contracts/utils/DaoArtifacts.sol
@@ -27,13 +27,7 @@ SOFTWARE.
  */
 
 contract DaoArtifacts {
-    enum ArtifactType {
-        CORE,
-        FACTORY,
-        EXTENSION,
-        ADAPTER,
-        UTIL
-    }
+    enum ArtifactType {CORE, FACTORY, EXTENSION, ADAPTER, UTIL}
 
     // Mapping from Artifact Name => (Owner Address => (Type => (Version => Adapters Address)))
     mapping(bytes32 => mapping(address => mapping(ArtifactType => mapping(bytes32 => address))))

--- a/contracts/utils/DaoArtifacts.sol
+++ b/contracts/utils/DaoArtifacts.sol
@@ -28,13 +28,7 @@ SOFTWARE.
 
 contract DaoArtifacts {
     // Types of artifacts that can be stored in this contract
-    enum ArtifactType {
-        CORE,
-        FACTORY,
-        EXTENSION,
-        ADAPTER,
-        UTIL
-    }
+    enum ArtifactType {CORE, FACTORY, EXTENSION, ADAPTER, UTIL}
 
     // Mapping from Artifact Name => (Owner Address => (Type => (Version => Adapters Address)))
     mapping(bytes32 => mapping(address => mapping(ArtifactType => mapping(bytes32 => address))))

--- a/contracts/utils/DaoArtifacts.sol
+++ b/contracts/utils/DaoArtifacts.sol
@@ -27,15 +27,17 @@ SOFTWARE.
  */
 
 contract DaoArtifacts {
-    enum ArtifactType {ADAPTER, EXTENSION}
+    enum ArtifactType {
+        CORE,
+        FACTORY,
+        EXTENSION,
+        ADAPTER,
+        UTIL
+    }
 
-    // Mapping from Artifact Name => (Owner Address => (Version => Adapters Address))
-    mapping(bytes32 => mapping(address => mapping(bytes32 => address)))
-        public adapters;
-
-    // Mapping from Artifact Name => (Owner Address => (Version => ExtensionsAddress))
-    mapping(bytes32 => mapping(address => mapping(bytes32 => address)))
-        public extensionsFactories;
+    // Mapping from Artifact Name => (Owner Address => (Type => (Version => Adapters Address)))
+    mapping(bytes32 => mapping(address => mapping(ArtifactType => mapping(bytes32 => address))))
+        public artifacts;
 
     event NewArtifact(
         bytes32 _id,
@@ -50,37 +52,17 @@ contract DaoArtifacts {
      * @param _id The id of the adapter (sha3).
      * @param _version The version of the adapter.
      * @param _address The address of the adapter to be stored.
+     * @param _type The artifact type:  0 = Core, 1 = Factory, 2 = Extension, 3 = Adapter, 4 = Util.
      */
-    function addAdapter(
+    function addArtifact(
         bytes32 _id,
         bytes32 _version,
-        address _address
+        address _address,
+        ArtifactType _type
     ) external {
         address _owner = msg.sender;
-        adapters[_id][_owner][_version] = _address;
-        emit NewArtifact(_id, _owner, _version, _address, ArtifactType.ADAPTER);
-    }
-
-    /**
-     * @notice Adds the extension factory address to the storage.
-     * @param _id The id of the extension factory (sha3).
-     * @param _version The version of the extension factory.
-     * @param _address The address of the extension factory to be stored.
-     */
-    function addExtensionFactory(
-        bytes32 _id,
-        bytes32 _version,
-        address _address
-    ) external {
-        address _owner = msg.sender;
-        extensionsFactories[_id][_owner][_version] = _address;
-        emit NewArtifact(
-            _id,
-            _owner,
-            _version,
-            _address,
-            ArtifactType.EXTENSION
-        );
+        artifacts[_id][_owner][_type][_version] = _address;
+        emit NewArtifact(_id, _owner, _version, _address, _type);
     }
 
     /**
@@ -88,7 +70,7 @@ contract DaoArtifacts {
      * @param _id The id of the adapter/extension factory (sha3).
      * @param _owner The address of the owner of the adapter/extension factory.
      * @param _version The version of the adapter/extension factory.
-     * @param _type The type of the artifact, 0 = Adapter, 1 = Extension Factory.
+     * @param _type The type of the artifact: 0 = Core, 1 = Factory, 2 = Extension, 3 = Adapter, 4 = Util.
      * @return The address of the adapter/extension factory if any.
      */
     function getArtifactAddress(
@@ -98,10 +80,7 @@ contract DaoArtifacts {
         ArtifactType _type
     ) external view returns (address) {
         if (_type == ArtifactType.ADAPTER) {
-            return adapters[_id][_owner][_version];
-        }
-        if (_type == ArtifactType.EXTENSION) {
-            return extensionsFactories[_id][_owner][_version];
+            return artifacts[_id][_owner][_type][_version];
         }
         return address(0x0);
     }

--- a/contracts/utils/DaoArtifacts.sol
+++ b/contracts/utils/DaoArtifacts.sol
@@ -27,7 +27,14 @@ SOFTWARE.
  */
 
 contract DaoArtifacts {
-    enum ArtifactType {CORE, FACTORY, EXTENSION, ADAPTER, UTIL}
+    // Types of artifacts that can be stored in this contract
+    enum ArtifactType {
+        CORE,
+        FACTORY,
+        EXTENSION,
+        ADAPTER,
+        UTIL
+    }
 
     // Mapping from Artifact Name => (Owner Address => (Type => (Version => Adapters Address)))
     mapping(bytes32 => mapping(address => mapping(ArtifactType => mapping(bytes32 => address))))

--- a/deployment/contracts.config.js
+++ b/deployment/contracts.config.js
@@ -1,0 +1,252 @@
+const contracts = [
+  // Test Util Contracts
+  {
+    name: "OLToken",
+    path: "../contracts/test/OLToken",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "TestToken1",
+    path: "../contracts/test/TestToken1",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "TestToken2",
+    path: "../contracts/test/TestToken2",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "TestFairShareCalc",
+    path: "../contracts/test/TestFairShareCalc",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "PixelNFT",
+    path: "../contracts/test/PixelNFT",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ProxToken",
+    path: "../contracts/test/ProxTokenContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ERC20Minter",
+    path: "../contracts/test/ERC20MinterContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+
+  // DAO Factories Contracts
+  {
+    name: "DaoFactory",
+    path: "../contracts/core/DaoFactory",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "DaoRegistry",
+    path: "../contracts/core/DaoRegistry",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "NFTCollectionFactory",
+    path: "../contracts/extensions/NFTCollectionFactory",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "BankFactory",
+    path: "../contracts/extensions/bank/BankFactory",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ERC20TokenExtensionFactory",
+    path: "../contracts/extensions/token/erc20/ERC20TokenExtensionFactory",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ExecutorExtensionFactory",
+    path: "../contracts/extensions/executor/ExecutorExtensionFactory",
+    enabled: true,
+    version: "1.0.0",
+  },
+
+  // Extensions
+  {
+    name: "NFTExtension",
+    path: "../contracts/extensions/nft/NFTExtension",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "BankExtension",
+    path: "../contracts/extensions/bank/BankExtension",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ERC20Extension",
+    path: "../contracts/extensions/token/erc20/ERC20Extension",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ExecutorExtension",
+    path: "../contracts/extensions/executor/ExecutorExtension",
+    enabled: true,
+    version: "1.0.0",
+  },
+
+  // Config Adapters
+  {
+    name: "DaoRegistryAdapterContract",
+    path: "../contracts/adapters/DaoRegistryAdapterContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "BankAdapterContract",
+    path: "../contracts/adapters/BankAdapterContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "NFTAdapterContract",
+    path: "../contracts/adapters/NFTAdapterContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ConfigurationContract",
+    path: "../contracts/adapters/ConfigurationContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "ManagingContract",
+    path: "../contracts/adapters/ManagingContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+
+  // Voting Adapters
+  {
+    name: "VotingContract",
+    path: "../contracts/adapters/VotingContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "SnapshotProposalContract",
+    path: "../contracts/adapters/voting/SnapshotProposalContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "OffchainVotingContract",
+    path: "../contracts/adapters/voting/OffchainVotingContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "OffchainVotingHashContract",
+    path: "../contracts/adapters/voting/OffchainVotingHashContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "KickBadReporterAdapter",
+    path: "../contracts/adapters/voting/KickBadReporterAdapter",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "BatchVotingContract",
+    path: "../contracts/adapters/voting/BatchVotingContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+
+  // Withdraw / Kick Adapters
+  {
+    name: "RagequitContract",
+    path: "../contracts/adapters/RagequitContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "GuildKickContract",
+    path: "../contracts/adapters/GuildKickContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "DistributeContract",
+    path: "../contracts/adapters/DistributeContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+
+  // Funding/Onboarding Adapters
+  {
+    name: "FinancingContract",
+    path: "../contracts/adapters/FinancingContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "OnboardingContract",
+    path: "../contracts/adapters/OnboardingContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "CouponOnboardingContract",
+    path: "../contracts/adapters/CouponOnboardingContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "TributeContract",
+    path: "../contracts/adapters/TributeContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "TributeNFTContract",
+    path: "../contracts/adapters/TributeNFTContract",
+    enabled: true,
+    version: "1.0.0",
+  },
+
+  // Utils
+  {
+    name: "DaoArtifacts",
+    path: "../contracts/utils/DaoArtifacts",
+    enabled: true,
+    version: "1.0.0",
+  },
+  {
+    name: "Multicall",
+    path: "../contracts/utils/Multicall",
+    enabled: true,
+    version: "1.0.0",
+  },
+];
+
+const isDeployable = (name) => {
+  const c = contracts.find((c) => c.name === name);
+  return c && c.enabled;
+};
+
+module.exports = contracts;

--- a/deployment/contracts.config.js
+++ b/deployment/contracts.config.js
@@ -1,12 +1,12 @@
 // Matches the DaoArtifacts.sol ArtifactType enum
-enum ContractType {
-  Core = 0,
-  Factory = 1,
-  Extension = 2,
-  Adapter = 3,
-  Util = 4,
-  Test = 5, 
-}
+const ContractType = {
+  Core: 0,
+  Factory: 1,
+  Extension: 2,
+  Adapter: 3,
+  Util: 4,
+  Test: 5,
+};
 
 const contracts = [
   // Test Util Contracts
@@ -15,49 +15,49 @@ const contracts = [
     path: "../contracts/test/OLToken",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Test
+    type: ContractType.Test,
   },
   {
     name: "TestToken1",
     path: "../contracts/test/TestToken1",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Test
+    type: ContractType.Test,
   },
   {
     name: "TestToken2",
     path: "../contracts/test/TestToken2",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Test
+    type: ContractType.Test,
   },
   {
     name: "TestFairShareCalc",
     path: "../contracts/test/TestFairShareCalc",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Test
+    type: ContractType.Test,
   },
   {
     name: "PixelNFT",
     path: "../contracts/test/PixelNFT",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Test
+    type: ContractType.Test,
   },
   {
     name: "ProxToken",
     path: "../contracts/test/ProxTokenContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Test
+    type: ContractType.Test,
   },
   {
     name: "ERC20Minter",
     path: "../contracts/test/ERC20MinterContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Test
+    type: ContractType.Test,
   },
 
   // DAO Factories Contracts
@@ -66,42 +66,42 @@ const contracts = [
     path: "../contracts/core/DaoFactory",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Factory
+    type: ContractType.Factory,
   },
   {
     name: "DaoRegistry",
     path: "../contracts/core/DaoRegistry",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Core
+    type: ContractType.Core,
   },
   {
     name: "NFTCollectionFactory",
     path: "../contracts/extensions/NFTCollectionFactory",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Factory
+    type: ContractType.Factory,
   },
   {
     name: "BankFactory",
     path: "../contracts/extensions/bank/BankFactory",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Factory
+    type: ContractType.Factory,
   },
   {
     name: "ERC20TokenExtensionFactory",
     path: "../contracts/extensions/token/erc20/ERC20TokenExtensionFactory",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Factory
+    type: ContractType.Factory,
   },
   {
     name: "ExecutorExtensionFactory",
     path: "../contracts/extensions/executor/ExecutorExtensionFactory",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Factory
+    type: ContractType.Factory,
   },
 
   // Extensions
@@ -110,28 +110,28 @@ const contracts = [
     path: "../contracts/extensions/nft/NFTExtension",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Extension
+    type: ContractType.Extension,
   },
   {
     name: "BankExtension",
     path: "../contracts/extensions/bank/BankExtension",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Extension
+    type: ContractType.Extension,
   },
   {
     name: "ERC20Extension",
     path: "../contracts/extensions/token/erc20/ERC20Extension",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Extension
+    type: ContractType.Extension,
   },
   {
     name: "ExecutorExtension",
     path: "../contracts/extensions/executor/ExecutorExtension",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Extension
+    type: ContractType.Extension,
   },
 
   // Config Adapters
@@ -140,35 +140,35 @@ const contracts = [
     path: "../contracts/adapters/DaoRegistryAdapterContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "BankAdapterContract",
     path: "../contracts/adapters/BankAdapterContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "NFTAdapterContract",
     path: "../contracts/adapters/NFTAdapterContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "ConfigurationContract",
     path: "../contracts/adapters/ConfigurationContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "ManagingContract",
     path: "../contracts/adapters/ManagingContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
 
   // Voting Adapters
@@ -177,42 +177,42 @@ const contracts = [
     path: "../contracts/adapters/VotingContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "SnapshotProposalContract",
     path: "../contracts/adapters/voting/SnapshotProposalContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "OffchainVotingContract",
     path: "../contracts/adapters/voting/OffchainVotingContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "OffchainVotingHashContract",
     path: "../contracts/adapters/voting/OffchainVotingHashContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "KickBadReporterAdapter",
     path: "../contracts/adapters/voting/KickBadReporterAdapter",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "BatchVotingContract",
     path: "../contracts/adapters/voting/BatchVotingContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
 
   // Withdraw / Kick Adapters
@@ -221,21 +221,21 @@ const contracts = [
     path: "../contracts/adapters/RagequitContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "GuildKickContract",
     path: "../contracts/adapters/GuildKickContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "DistributeContract",
     path: "../contracts/adapters/DistributeContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
 
   // Funding/Onboarding Adapters
@@ -244,35 +244,35 @@ const contracts = [
     path: "../contracts/adapters/FinancingContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "OnboardingContract",
     path: "../contracts/adapters/OnboardingContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "CouponOnboardingContract",
     path: "../contracts/adapters/CouponOnboardingContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "TributeContract",
     path: "../contracts/adapters/TributeContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
   {
     name: "TributeNFTContract",
     path: "../contracts/adapters/TributeNFTContract",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Adapter
+    type: ContractType.Adapter,
   },
 
   // Utils
@@ -281,14 +281,14 @@ const contracts = [
     path: "../contracts/utils/DaoArtifacts",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Util
+    type: ContractType.Util,
   },
   {
     name: "Multicall",
     path: "../contracts/utils/Multicall",
     enabled: true,
     version: "1.0.0",
-    type: ContractType.Util
+    type: ContractType.Util,
   },
 ];
 

--- a/deployment/contracts.config.js
+++ b/deployment/contracts.config.js
@@ -1,3 +1,13 @@
+// Matches the DaoArtifacts.sol ArtifactType enum
+enum ContractType {
+  Core = 0,
+  Factory = 1,
+  Extension = 2,
+  Adapter = 3,
+  Util = 4,
+  Test = 5, 
+}
+
 const contracts = [
   // Test Util Contracts
   {
@@ -5,42 +15,49 @@ const contracts = [
     path: "../contracts/test/OLToken",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Test
   },
   {
     name: "TestToken1",
     path: "../contracts/test/TestToken1",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Test
   },
   {
     name: "TestToken2",
     path: "../contracts/test/TestToken2",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Test
   },
   {
     name: "TestFairShareCalc",
     path: "../contracts/test/TestFairShareCalc",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Test
   },
   {
     name: "PixelNFT",
     path: "../contracts/test/PixelNFT",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Test
   },
   {
     name: "ProxToken",
     path: "../contracts/test/ProxTokenContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Test
   },
   {
     name: "ERC20Minter",
     path: "../contracts/test/ERC20MinterContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Test
   },
 
   // DAO Factories Contracts
@@ -49,36 +66,42 @@ const contracts = [
     path: "../contracts/core/DaoFactory",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Factory
   },
   {
     name: "DaoRegistry",
     path: "../contracts/core/DaoRegistry",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Core
   },
   {
     name: "NFTCollectionFactory",
     path: "../contracts/extensions/NFTCollectionFactory",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Factory
   },
   {
     name: "BankFactory",
     path: "../contracts/extensions/bank/BankFactory",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Factory
   },
   {
     name: "ERC20TokenExtensionFactory",
     path: "../contracts/extensions/token/erc20/ERC20TokenExtensionFactory",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Factory
   },
   {
     name: "ExecutorExtensionFactory",
     path: "../contracts/extensions/executor/ExecutorExtensionFactory",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Factory
   },
 
   // Extensions
@@ -87,24 +110,28 @@ const contracts = [
     path: "../contracts/extensions/nft/NFTExtension",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Extension
   },
   {
     name: "BankExtension",
     path: "../contracts/extensions/bank/BankExtension",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Extension
   },
   {
     name: "ERC20Extension",
     path: "../contracts/extensions/token/erc20/ERC20Extension",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Extension
   },
   {
     name: "ExecutorExtension",
     path: "../contracts/extensions/executor/ExecutorExtension",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Extension
   },
 
   // Config Adapters
@@ -113,30 +140,35 @@ const contracts = [
     path: "../contracts/adapters/DaoRegistryAdapterContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "BankAdapterContract",
     path: "../contracts/adapters/BankAdapterContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "NFTAdapterContract",
     path: "../contracts/adapters/NFTAdapterContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "ConfigurationContract",
     path: "../contracts/adapters/ConfigurationContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "ManagingContract",
     path: "../contracts/adapters/ManagingContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
 
   // Voting Adapters
@@ -145,36 +177,42 @@ const contracts = [
     path: "../contracts/adapters/VotingContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "SnapshotProposalContract",
     path: "../contracts/adapters/voting/SnapshotProposalContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "OffchainVotingContract",
     path: "../contracts/adapters/voting/OffchainVotingContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "OffchainVotingHashContract",
     path: "../contracts/adapters/voting/OffchainVotingHashContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "KickBadReporterAdapter",
     path: "../contracts/adapters/voting/KickBadReporterAdapter",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "BatchVotingContract",
     path: "../contracts/adapters/voting/BatchVotingContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
 
   // Withdraw / Kick Adapters
@@ -183,18 +221,21 @@ const contracts = [
     path: "../contracts/adapters/RagequitContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "GuildKickContract",
     path: "../contracts/adapters/GuildKickContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "DistributeContract",
     path: "../contracts/adapters/DistributeContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
 
   // Funding/Onboarding Adapters
@@ -203,30 +244,35 @@ const contracts = [
     path: "../contracts/adapters/FinancingContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "OnboardingContract",
     path: "../contracts/adapters/OnboardingContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "CouponOnboardingContract",
     path: "../contracts/adapters/CouponOnboardingContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "TributeContract",
     path: "../contracts/adapters/TributeContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
   {
     name: "TributeNFTContract",
     path: "../contracts/adapters/TributeNFTContract",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Adapter
   },
 
   // Utils
@@ -235,18 +281,24 @@ const contracts = [
     path: "../contracts/utils/DaoArtifacts",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Util
   },
   {
     name: "Multicall",
     path: "../contracts/utils/Multicall",
     enabled: true,
     version: "1.0.0",
+    type: ContractType.Util
   },
 ];
 
+const getConfig = (name) => {
+  return contracts.find((c) => c.name === name);
+};
+
 const isDeployable = (name) => {
-  const c = contracts.find((c) => c.name === name);
+  const c = getConfig(name);
   return c && c.enabled;
 };
 
-module.exports = contracts;
+module.exports = { contracts, getConfig, isDeployable, ContractType };

--- a/deployment/ganache.config.js
+++ b/deployment/ganache.config.js
@@ -1,0 +1,20 @@
+const contracts = require("./contracts.config");
+
+const disabled = [
+  "OLToken",
+  "TestToken1",
+  "TestToken2",
+  "TestFairShareCalc",
+  "PixelNFT",
+  "ProxToken",
+  "ERC20Minter",
+];
+
+const ganacheContracts = contracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});
+
+module.exports = { contracts: ganacheContracts };

--- a/deployment/ganache.config.js
+++ b/deployment/ganache.config.js
@@ -1,7 +1,14 @@
 const { contracts } = require("./contracts.config");
 
 const disabled = [
-  // "ERC20Minter",
+  // Utility & Test Contracts disabled by default
+  "OLToken",
+  "TestToken1",
+  "TestToken2",
+  "TestFairShareCalc",
+  "PixelNFT",
+  "ProxToken",
+  "ERC20Minter",
 ];
 
 const ganacheContracts = contracts.map((c) => {

--- a/deployment/ganache.config.js
+++ b/deployment/ganache.config.js
@@ -1,13 +1,7 @@
 const contracts = require("./contracts.config");
 
 const disabled = [
-  "OLToken",
-  "TestToken1",
-  "TestToken2",
-  "TestFairShareCalc",
-  "PixelNFT",
-  "ProxToken",
-  "ERC20Minter",
+  // "ERC20Minter",
 ];
 
 const ganacheContracts = contracts.map((c) => {

--- a/deployment/ganache.config.js
+++ b/deployment/ganache.config.js
@@ -1,4 +1,4 @@
-const contracts = require("./contracts.config");
+const { contracts } = require("./contracts.config");
 
 const disabled = [
   // "ERC20Minter",

--- a/deployment/mainnet.config.js
+++ b/deployment/mainnet.config.js
@@ -1,0 +1,20 @@
+const contracts = require("./contracts.config");
+
+const disabled = [
+  "OLToken",
+  "TestToken1",
+  "TestToken2",
+  "TestFairShareCalc",
+  "PixelNFT",
+  "ProxToken",
+  "ERC20Minter",
+];
+
+const mainnetContracts = contracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});
+
+module.exports = { contracts: mainnetContracts };

--- a/deployment/mainnet.config.js
+++ b/deployment/mainnet.config.js
@@ -1,4 +1,4 @@
-const contracts = require("./contracts.config");
+const { contracts } = require("./contracts.config");
 
 const disabled = [
   "OLToken",

--- a/deployment/mainnet.config.js
+++ b/deployment/mainnet.config.js
@@ -1,6 +1,7 @@
 const { contracts } = require("./contracts.config");
 
 const disabled = [
+  // Utility & Test Contracts disabled by default
   "OLToken",
   "TestToken1",
   "TestToken2",
@@ -8,6 +9,12 @@ const disabled = [
   "PixelNFT",
   "ProxToken",
   "ERC20Minter",
+  // Adapters disabled for Muse0 DAO Deployment
+  "RagequitContract",
+  "FinancingContract",
+  "OnboardingContract",
+  "TributeContract",
+  "DistributeContract",
 ];
 
 const mainnetContracts = contracts.map((c) => {

--- a/deployment/rinkeby.config.js
+++ b/deployment/rinkeby.config.js
@@ -1,0 +1,12 @@
+const contracts = require("./contracts.config");
+
+const disabled = [];
+
+const rinkebyContracts = contracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});
+
+module.exports = { contracts: rinkebyContracts };

--- a/deployment/rinkeby.config.js
+++ b/deployment/rinkeby.config.js
@@ -1,6 +1,15 @@
 const { contracts } = require("./contracts.config");
 
-const disabled = [];
+const disabled = [
+  // Utility & Test Contracts disabled by default
+  "OLToken",
+  "TestToken1",
+  "TestToken2",
+  "TestFairShareCalc",
+  "PixelNFT",
+  "ProxToken",
+  "ERC20Minter",
+];
 
 const rinkebyContracts = contracts.map((c) => {
   if (disabled.find((e) => e === c.name)) {

--- a/deployment/rinkeby.config.js
+++ b/deployment/rinkeby.config.js
@@ -1,4 +1,4 @@
-const contracts = require("./contracts.config");
+const { contracts } = require("./contracts.config");
 
 const disabled = [];
 

--- a/deployment/test.config.js
+++ b/deployment/test.config.js
@@ -1,0 +1,20 @@
+const contracts = require("./contracts.config");
+
+const disabled = [
+  "OLToken",
+  "TestToken1",
+  "TestToken2",
+  "TestFairShareCalc",
+  "PixelNFT",
+  "ProxToken",
+  "ERC20Minter",
+];
+
+const testContracts = contracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});
+
+module.exports = { contracts: testContracts };

--- a/deployment/test.config.js
+++ b/deployment/test.config.js
@@ -1,4 +1,4 @@
-const contracts = require("./contracts.config");
+const { contracts } = require("./contracts.config");
 
 const disabled = [];
 

--- a/deployment/test.config.js
+++ b/deployment/test.config.js
@@ -1,14 +1,6 @@
 const contracts = require("./contracts.config");
 
-const disabled = [
-  "OLToken",
-  "TestToken1",
-  "TestToken2",
-  "TestFairShareCalc",
-  "PixelNFT",
-  "ProxToken",
-  "ERC20Minter",
-];
+const disabled = [];
 
 const testContracts = contracts.map((c) => {
   if (disabled.find((e) => e === c.name)) {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -168,7 +168,6 @@ const deployRinkebyDao = async (
     daoName: process.env.DAO_NAME,
     owner: process.env.DAO_OWNER_ADDR,
     offchainAdmin: "0xedC10CFA90A135C41538325DD57FDB4c7b88faf7",
-    contracts,
   });
 };
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -9,19 +9,40 @@ const {
 
 const { deployDao, getNetworkDetails } = require("../utils/DeploymentUtil.js");
 
-const truffleImports = require("../utils/TruffleUtil.js");
-
 require("dotenv").config();
 
 module.exports = async (deployer, network, accounts) => {
   let res;
+
+  console.log(`Starting deployment to ${network}`);
+
+  const { contracts } = require(`../deployment/${network}.config`);
+  const truffleImports = require("../utils/TruffleUtil.js")(contracts);
   const deployFunction = truffleImports.deployFunctionFactory(deployer);
+
   if (network === "ganache") {
-    res = await deployGanacheDao(deployFunction, network, accounts);
+    res = await deployGanacheDao(
+      deployFunction,
+      network,
+      accounts,
+      contracts,
+      truffleImports
+    );
   } else if (network === "rinkeby") {
-    res = await deployRinkebyDao(deployFunction, network);
+    res = await deployRinkebyDao(
+      deployFunction,
+      network,
+      contracts,
+      truffleImports
+    );
   } else if (network === "test" || network === "coverage") {
-    res = await deployTestDao(deployFunction, network, accounts);
+    res = await deployTestDao(
+      deployFunction,
+      network,
+      accounts,
+      contracts,
+      truffleImports
+    );
   }
   let { dao, extensions, testContracts } = res;
   if (dao) {
@@ -50,7 +71,13 @@ module.exports = async (deployer, network, accounts) => {
   }
 };
 
-async function deployTestDao(deployFunction, network, accounts) {
+const deployTestDao = async (
+  deployFunction,
+  network,
+  accounts,
+  contracts,
+  truffleImports
+) => {
   if (!process.env.DAO_NAME) throw Error("Missing env var: DAO_NAME");
   if (!process.env.ERC20_TOKEN_NAME)
     throw Error("Missing env var: ERC20_TOKEN_NAME");
@@ -80,10 +107,16 @@ async function deployTestDao(deployFunction, network, accounts) {
     offchainAdmin: "0xedC10CFA90A135C41538325DD57FDB4c7b88faf7",
     daoName: process.env.DAO_NAME,
     owner: accounts[0],
+    contracts,
   });
-}
+};
 
-async function deployRinkebyDao(deployFunction, network) {
+const deployRinkebyDao = async (
+  deployFunction,
+  network,
+  contracts,
+  truffleImports
+) => {
   if (!process.env.DAO_NAME) throw Error("Missing env var: DAO_NAME");
   if (!process.env.DAO_OWNER_ADDR)
     throw Error("Missing env var: DAO_OWNER_ADDR");
@@ -117,10 +150,17 @@ async function deployRinkebyDao(deployFunction, network) {
     daoName: process.env.DAO_NAME,
     owner: process.env.DAO_OWNER_ADDR,
     offchainAdmin: "0xedC10CFA90A135C41538325DD57FDB4c7b88faf7",
+    contracts,
   });
-}
+};
 
-async function deployGanacheDao(deployFunction, network, accounts) {
+const deployGanacheDao = async (
+  deployFunction,
+  network,
+  accounts,
+  contracts,
+  truffleImports
+) => {
   if (!process.env.DAO_NAME) throw Error("Missing env var: DAO_NAME");
   if (!process.env.ERC20_TOKEN_NAME)
     throw Error("Missing env var: ERC20_TOKEN_NAME");
@@ -152,5 +192,6 @@ async function deployGanacheDao(deployFunction, network, accounts) {
     daoName: process.env.DAO_NAME,
     owner: accounts[0],
     offchainAdmin: "0xedC10CFA90A135C41538325DD57FDB4c7b88faf7",
+    contracts,
   });
-}
+};

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -14,23 +14,24 @@ require("dotenv").config();
 module.exports = async (deployer, network, accounts) => {
   let res;
 
-  console.log(`Starting deployment to ${network}`);
+  console.log(`Deploying tribute-contracts to ${network} network`);
 
   const { contracts } = require(`../deployment/${network}.config`);
   const truffleImports = require("../utils/TruffleUtil.js")(contracts);
+  const DaoArtifacts = truffleImports.DaoArtifacts;
 
-  var daoArtifacts = truffleImports.DaoArtifacts;
+  let daoArtifacts;
   if (process.env.DAO_ARTIFACTS_CONTRACT_ADDR) {
-    console.log(
-      `Attach to existing DaoArtifacts contract: ${process.env.DAO_ARTIFACTS_CONTRACT_ADDR}`
-    );
-    daoArtifacts = await truffleImports.DaoArtifacts.at(
+    console.log(`Attach to existing DaoArtifacts contract`);
+    daoArtifacts = await DaoArtifacts.at(
       process.env.DAO_ARTIFACTS_CONTRACT_ADDR
     );
   } else {
-    daoArtifacts = await deployer.deploy(truffleImports.DaoArtifacts);
-    console.log(`Deployed new DaoArtifacts contract: ${daoArtifacts.address}`);
+    console.log(`Creating new DaoArtifacts contract`);
+    await deployer.deploy(DaoArtifacts);
+    daoArtifacts = await DaoArtifacts.deployed();
   }
+  console.log(`DaoArtifacts: ${daoArtifacts.address}`);
 
   const deployFunction = truffleImports.deployFunctionFactory(
     deployer,

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -18,7 +18,24 @@ module.exports = async (deployer, network, accounts) => {
 
   const { contracts } = require(`../deployment/${network}.config`);
   const truffleImports = require("../utils/TruffleUtil.js")(contracts);
-  const deployFunction = truffleImports.deployFunctionFactory(deployer);
+
+  var daoArtifacts = truffleImports.DaoArtifacts;
+  if (process.env.DAO_ARTIFACTS_CONTRACT_ADDR) {
+    console.log(
+      `Attach to existing DaoArtifacts contract: ${process.env.DAO_ARTIFACTS_CONTRACT_ADDR}`
+    );
+    daoArtifacts = await truffleImports.DaoArtifacts.at(
+      process.env.DAO_ARTIFACTS_CONTRACT_ADDR
+    );
+  } else {
+    daoArtifacts = await deployer.deploy(truffleImports.DaoArtifacts);
+    console.log(`Deployed new DaoArtifacts contract: ${daoArtifacts.address}`);
+  }
+
+  const deployFunction = truffleImports.deployFunctionFactory(
+    deployer,
+    daoArtifacts
+  );
 
   if (network === "ganache") {
     res = await deployGanacheDao(

--- a/test/extensions/executor.test.js
+++ b/test/extensions/executor.test.js
@@ -30,7 +30,6 @@ const { sha3, toBN } = require("../../utils/ContractUtil.js");
 const {
   deployDefaultDao,
   entryDao,
-  entryBank,
   entryExecutor,
   ERC20Minter,
   ProxToken,

--- a/test/utils/dao-artifacts.test.js
+++ b/test/utils/dao-artifacts.test.js
@@ -1,8 +1,6 @@
 // Whole-script strict mode syntax
 "use strict";
 
-const expectEvent = require("@openzeppelin/test-helpers/src/expectEvent");
-const { toBN } = require("web3-utils");
 /**
 MIT License
 
@@ -26,10 +24,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
+const expectEvent = require("@openzeppelin/test-helpers/src/expectEvent");
 const { sha3 } = require("../../utils/ContractUtil.js");
-
+const { toBN } = require("web3-utils");
 const { accounts, expect, DaoArtifacts } = require("../../utils/OZTestUtil.js");
-
 const { ContractType } = require("../../deployment/contracts.config");
 
 describe("Utils - DaoArtifacts", () => {

--- a/test/utils/dao-artifacts.test.js
+++ b/test/utils/dao-artifacts.test.js
@@ -30,6 +30,8 @@ const { sha3 } = require("../../utils/ContractUtil.js");
 
 const { accounts, expect, DaoArtifacts } = require("../../utils/OZTestUtil.js");
 
+const { ContractType } = require("../../deployment/contracts.config");
+
 describe("Utils - DaoArtifacts", () => {
   it("should be possible to create a dao artifacts contract", async () => {
     const daoArtifacts = await DaoArtifacts.new();
@@ -43,10 +45,11 @@ describe("Utils - DaoArtifacts", () => {
     const daoArtifacts = await DaoArtifacts.new();
     const owner = accounts[2];
     const adapterAddress = accounts[9];
-    const res = await daoArtifacts.addAdapter(
+    const res = await daoArtifacts.addArtifact(
       sha3("adapter1"),
       sha3("v1.0.0"),
       adapterAddress,
+      ContractType.Adapter,
       { from: owner }
     );
     expectEvent(res, "NewArtifact", {
@@ -54,7 +57,7 @@ describe("Utils - DaoArtifacts", () => {
       _owner: owner,
       _version: sha3("v1.0.0"),
       _address: adapterAddress,
-      _type: toBN("0"),
+      _type: toBN("3"),
     });
   });
 
@@ -63,10 +66,11 @@ describe("Utils - DaoArtifacts", () => {
     const owner = accounts[2];
     const adapterAddress = accounts[9];
 
-    await daoArtifacts.addAdapter(
+    await daoArtifacts.addArtifact(
       sha3("adapter1"),
       sha3("v1.0.0"),
       adapterAddress,
+      ContractType.Adapter,
       { from: owner }
     );
 
@@ -74,7 +78,7 @@ describe("Utils - DaoArtifacts", () => {
       sha3("adapter1"),
       owner,
       sha3("v1.0.0"),
-      toBN("0") //Type = adapter
+      ContractType.Adapter
     );
     expect(address).to.be.equal(adapterAddress);
   });
@@ -83,10 +87,11 @@ describe("Utils - DaoArtifacts", () => {
     const daoArtifacts = await DaoArtifacts.new();
     const owner = accounts[2];
     const extensionAddress = accounts[9];
-    const res = await daoArtifacts.addExtensionFactory(
+    const res = await daoArtifacts.addArtifact(
       sha3("extFactory1"),
       sha3("v1.0.0"),
       extensionAddress,
+      ContractType.Extension,
       { from: owner }
     );
     expectEvent(res, "NewArtifact", {
@@ -94,7 +99,7 @@ describe("Utils - DaoArtifacts", () => {
       _owner: owner,
       _version: sha3("v1.0.0"),
       _address: extensionAddress,
-      _type: toBN("1"),
+      _type: toBN("2"),
     });
   });
 
@@ -102,18 +107,19 @@ describe("Utils - DaoArtifacts", () => {
     const daoArtifacts = await DaoArtifacts.new();
     const owner = accounts[2];
     const extensionAddress = accounts[9];
-    await daoArtifacts.addExtensionFactory(
-      sha3("extFactory1"),
+    await daoArtifacts.addArtifact(
+      sha3("extFactory2"),
       sha3("v1.0.0"),
       extensionAddress,
+      ContractType.Extension,
       { from: owner }
     );
 
     const address = await daoArtifacts.getArtifactAddress(
-      sha3("extFactory1"),
+      sha3("extFactory2"),
       owner,
       sha3("v1.0.0"),
-      toBN("1") //Type = adapter
+      ContractType.Extension
     );
     expect(address).to.be.equal(extensionAddress);
   });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -29,12 +29,11 @@ module.exports = {
       network_id: "1337", // Any network (default: none)
     },
     rinkeby: {
-      provider: function () {
-        let HDWalletProvider = require("@truffle/hdwallet-provider");
-
-        let infuraKey = process.env.INFURA_KEY;
-        let alchemyKey = process.env.ALCHEMY_KEY;
-        let mnemonic = process.env.TRUFFLE_MNEMONIC;
+      provider: () => {
+        const HDWalletProvider = require("@truffle/hdwallet-provider");
+        const infuraKey = process.env.INFURA_KEY;
+        const alchemyKey = process.env.ALCHEMY_KEY;
+        const mnemonic = process.env.TRUFFLE_MNEMONIC;
 
         let url;
         if (alchemyKey) {
@@ -51,10 +50,32 @@ module.exports = {
         });
       },
       network_id: 4,
-      gasPrice: 10000000000,
       skipDryRun: true,
       networkCheckTimeout: 10000,
       deploymentPollingInterval: 10000,
+    },
+    mainnet: {
+      provider: () => {
+        const HDWalletProvider = require("@truffle/hdwallet-provider");
+        const infuraKey = process.env.INFURA_KEY;
+        const alchemyKey = process.env.ALCHEMY_KEY;
+        const mnemonic = process.env.TRUFFLE_MNEMONIC;
+
+        let url;
+        if (alchemyKey) {
+          url = `wss://eth-mainnet.ws.alchemyapi.io/v2/${alchemyKey}`;
+        } else {
+          url = `wss://mainnet.infura.io/ws/v3/${infuraKey}`;
+        }
+        return new HDWalletProvider({
+          mnemonic: {
+            phrase: mnemonic,
+          },
+          providerOrUrl: url,
+        });
+      },
+      network_id: 1,
+      skipDryRun: true,
     },
     coverage: {
       host: "localhost",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -30,11 +30,12 @@ module.exports = {
     },
     rinkeby: {
       provider: function () {
+        let HDWalletProvider = require("@truffle/hdwallet-provider");
+
         let infuraKey = process.env.INFURA_KEY;
         let alchemyKey = process.env.ALCHEMY_KEY;
-
-        let HDWalletProvider = require("@truffle/hdwallet-provider");
         let mnemonic = process.env.TRUFFLE_MNEMONIC;
+
         let url;
         if (alchemyKey) {
           url = `wss://eth-rinkeby.ws.alchemyapi.io/v2/${alchemyKey}`;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -31,10 +31,17 @@ module.exports = {
     rinkeby: {
       provider: function () {
         let infuraKey = process.env.INFURA_KEY;
+        let alchemyKey = process.env.ALCHEMY_KEY;
+
         let HDWalletProvider = require("@truffle/hdwallet-provider");
         let mnemonic = process.env.TRUFFLE_MNEMONIC;
-        let infuraUrl = "wss://rinkeby.infura.io/ws/v3/" + infuraKey;
-        return new HDWalletProvider(mnemonic, infuraUrl);
+        let url;
+        if (alchemyKey) {
+          url = `wss://eth-rinkeby.ws.alchemyapi.io/v2/${alchemyKey}`;
+        } else {
+          url = `wss://rinkeby.infura.io/ws/v3/${infuraKey}`;
+        }
+        return new HDWalletProvider(mnemonic, url);
       },
       network_id: 4,
       gasPrice: 10000000000,

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -42,11 +42,19 @@ module.exports = {
         } else {
           url = `wss://rinkeby.infura.io/ws/v3/${infuraKey}`;
         }
-        return new HDWalletProvider(mnemonic, url);
+        return new HDWalletProvider({
+          mnemonic: {
+            phrase: mnemonic,
+          },
+          providerOrUrl: url,
+          pollingInterval: 10000,
+        });
       },
       network_id: 4,
       gasPrice: 10000000000,
       skipDryRun: true,
+      networkCheckTimeout: 10000,
+      deploymentPollingInterval: 10000,
     },
     coverage: {
       host: "localhost",

--- a/utils/ContractUtil.js
+++ b/utils/ContractUtil.js
@@ -24,7 +24,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
-
 const Web3Utils = require("web3-utils");
 const sha3 = Web3Utils.sha3;
 const toBN = Web3Utils.toBN;
@@ -49,65 +48,7 @@ const unitPrice = toBN(toWei("120", "finney"));
 const remaining = unitPrice.sub(toBN("50000000000000"));
 const maximumChunks = toBN("11");
 
-const contracts = {
-  // Test Util Contracts
-  OLToken: "./test/OLToken",
-  TestToken1: "./test/TestToken1",
-  TestToken2: "./test/TestToken2",
-  TestFairShareCalc: "./test/TestFairShareCalc",
-  PixelNFT: "./test/PixelNFT",
-  ProxToken: "./test/ProxTokenContract",
-  ERC20Minter: "./test/ERC20MinterContract",
-
-  // DAO Contracts
-  DaoFactory: "./core/DaoFactory",
-  DaoRegistry: "./core/DaoRegistry",
-  NFTCollectionFactory: "./extensions/NFTCollectionFactory",
-  BankFactory: "./extensions/bank/BankFactory",
-  ERC20TokenExtensionFactory:
-    "./extensions/token/erc20/ERC20TokenExtensionFactory",
-  ExecutorExtensionFactory: "./extensions/executor/ExecutorExtensionFactory",
-  Multicall: "./util/Multicall",
-
-  // Extensions
-  NFTExtension: "./extensions/nft/NFTExtension",
-  BankExtension: "./extensions/bank/BankExtension",
-  ERC20Extension: "./extensions/token/erc20/ERC20Extension",
-  ExecutorExtension: "./extensions/token/executor/ExecutorExtension",
-
-  // Config Adapters
-  DaoRegistryAdapterContract: "./adapters/DaoRegistryAdapterContract",
-  BankAdapterContract: "./adapters/BankAdapterContract",
-  NFTAdapterContract: "./adapters/NFTAdapterContract",
-  ConfigurationContract: "./adapters/ConfigurationContract",
-  ManagingContract: "./adapters/ManagingContract",
-
-  // Voting Adapters
-  VotingContract: "./adapters/VotingContract",
-  SnapshotProposalContract: "./adapters/voting/SnapshotProposalContract",
-  OffchainVotingContract: "./adapters/voting/OffchainVotingContract",
-  OffchainVotingHashContract: "./adapters/voting/OffchainVotingHashContract",
-  KickBadReporterAdapter: "./adapters/voting/KickBadReporterAdapter",
-  BatchVotingContract: "./adapters/voting/BatchVotingContract",
-
-  // Withdraw Adapters
-  RagequitContract: "./adapters/RagequitContract",
-  GuildKickContract: "./adapters/GuildKickContract",
-  DistributeContract: "./adapters/DistributeContract",
-
-  // Funding/Onboarding Adapters
-  FinancingContract: "./adapters/FinancingContract",
-  OnboardingContract: "./adapters/OnboardingContract",
-  CouponOnboardingContract: "./adapters/CouponOnboardingContract",
-  TributeContract: "./adapters/TributeContract",
-  TributeNFTContract: "./adapters/TributeNFTContract",
-
-  // Utils
-  DaoArtifacts: "./utils/DaoArtifacts",
-};
-
 module.exports = {
-  contracts,
   sha3,
   toBN,
   toWei,

--- a/utils/ContractUtil.js
+++ b/utils/ContractUtil.js
@@ -33,6 +33,7 @@ const hexToBytes = Web3Utils.hexToBytes;
 const toAscii = Web3Utils.toAscii;
 const fromAscii = Web3Utils.fromAscii;
 const toUtf8 = Web3Utils.toUtf8;
+const toHex = Web3Utils.toHex;
 
 const GUILD = "0x000000000000000000000000000000000000dead";
 const TOTAL = "0x000000000000000000000000000000000000babe";
@@ -42,6 +43,7 @@ const UNITS = "0x00000000000000000000000000000000000FF1CE";
 const LOOT = "0x00000000000000000000000000000000B105F00D";
 const ETH_TOKEN = "0x0000000000000000000000000000000000000000";
 const DAI_TOKEN = "0x95b58a6bff3d14b7db2f5cb5f0ad413dc2940658";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const numberOfUnits = toBN("1000000000000000");
 const unitPrice = toBN(toWei("120", "finney"));
@@ -57,6 +59,7 @@ module.exports = {
   toAscii,
   fromAscii,
   toUtf8,
+  toHex,
   maximumChunks,
   numberOfUnits,
   unitPrice,
@@ -69,4 +72,5 @@ module.exports = {
   MEMBER_COUNT,
   LOOT,
   ETH_TOKEN,
+  ZERO_ADDRESS,
 };

--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -48,6 +48,7 @@ const deployDao = async (options) => {
     PixelNFT,
     OLToken,
     ProxToken,
+    contracts,
   } = options;
 
   const erc20TokenName = options.erc20TokenName
@@ -61,7 +62,6 @@ const deployDao = async (options) => {
     : 0;
 
   const identityDao = await deployFunction(DaoRegistry);
-
   const identityBank = await deployFunction(BankExtension);
   const bankFactory = await deployFunction(BankFactory, [identityBank.address]);
 

--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -48,7 +48,6 @@ const deployDao = async (options) => {
     PixelNFT,
     OLToken,
     ProxToken,
-    interfaces,
   } = options;
 
   const erc20TokenName = options.erc20TokenName

--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -48,7 +48,7 @@ const deployDao = async (options) => {
     PixelNFT,
     OLToken,
     ProxToken,
-    contracts,
+    interfaces,
   } = options;
 
   const erc20TokenName = options.erc20TokenName

--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -483,116 +483,209 @@ const configureDao = async ({
   gracePeriod,
   couponCreatorAddress,
 }) => {
-  await daoFactory.addAdapters(
-    dao.address,
-    [
-      entryDao("voting", voting, {}),
+  const adapters = [];
+  if (voting) adapters.push(entryDao("voting", voting, {}));
+
+  if (configuration)
+    adapters.push(
       entryDao("configuration", configuration, {
         SUBMIT_PROPOSAL: true,
         SET_CONFIGURATION: true,
-      }),
-      entryDao("ragequit", ragequit, {}),
+      })
+    );
+
+  if (ragequit) adapters.push(entryDao("ragequit", ragequit, {}));
+
+  if (guildkick)
+    adapters.push(
       entryDao("guildkick", guildkick, {
         SUBMIT_PROPOSAL: true,
-      }),
+      })
+    );
+
+  if (managing)
+    adapters.push(
       entryDao("managing", managing, {
         SUBMIT_PROPOSAL: true,
         REPLACE_ADAPTER: true,
-      }),
+      })
+    );
+
+  if (financing)
+    adapters.push(
       entryDao("financing", financing, {
         SUBMIT_PROPOSAL: true,
-      }),
+      })
+    );
+
+  if (onboarding)
+    adapters.push(
       entryDao("onboarding", onboarding, {
         SUBMIT_PROPOSAL: true,
         UPDATE_DELEGATE_KEY: true,
         NEW_MEMBER: true,
-      }),
+      })
+    );
+
+  if (couponOnboarding)
+    adapters.push(
       entryDao("coupon-onboarding", couponOnboarding, {
         NEW_MEMBER: true,
-      }),
+      })
+    );
+
+  if (daoRegistryAdapter)
+    adapters.push(
       entryDao("daoRegistry", daoRegistryAdapter, {
         UPDATE_DELEGATE_KEY: true,
-      }),
+      })
+    );
+
+  if (tribute)
+    adapters.push(
       entryDao("tribute", tribute, {
         SUBMIT_PROPOSAL: true,
         NEW_MEMBER: true,
-      }),
+      })
+    );
+
+  if (tributeNFT)
+    adapters.push(
       entryDao("tribute-nft", tributeNFT, {
         SUBMIT_PROPOSAL: true,
         NEW_MEMBER: true,
-      }),
+      })
+    );
+
+  if (distribute)
+    adapters.push(
       entryDao("distribute", distribute, {
         SUBMIT_PROPOSAL: true,
-      }),
-      // Adapters to access the extensions directly
-      entryDao("nft", nftAdapter, {}),
-      entryDao("bank", bankAdapter, {}),
-      // Declare the erc20 token extension as an adapter to be able to call the bank extension
+      })
+    );
+
+  // Adapters to access the extensions directly
+  if (nftAdapter) adapters.push(entryDao("nft", nftAdapter, {}));
+
+  if (bankAdapter) adapters.push(entryDao("bank", bankAdapter, {}));
+
+  // Declare the erc20 token extension as an adapter to be able to call the bank extension
+  if (erc20TokenExtension)
+    adapters.push(
       entryDao("erc20-ext", erc20TokenExtension, {
         NEW_MEMBER: true,
-      }),
-    ],
-    { from: owner }
-  );
+      })
+    );
 
-  await daoFactory.configureExtension(
-    dao.address,
-    bankExtension.address,
-    [
+  await daoFactory.addAdapters(dao.address, adapters, { from: owner });
+
+  const adaptersWithBankAccess = [];
+
+  if (ragequit)
+    adaptersWithBankAccess.push(
       entryBank(ragequit, {
         INTERNAL_TRANSFER: true,
         SUB_FROM_BALANCE: true,
         ADD_TO_BALANCE: true,
-      }),
+      })
+    );
+
+  if (guildkick)
+    adaptersWithBankAccess.push(
       entryBank(guildkick, {
         INTERNAL_TRANSFER: true,
         SUB_FROM_BALANCE: true,
         ADD_TO_BALANCE: true,
-      }),
+      })
+    );
+
+  if (bankAdapter)
+    adaptersWithBankAccess.push(
       entryBank(bankAdapter, {
         WITHDRAW: true,
         SUB_FROM_BALANCE: true,
         UPDATE_TOKEN: true,
-      }),
+      })
+    );
+
+  if (onboarding)
+    adaptersWithBankAccess.push(
       entryBank(onboarding, {
         ADD_TO_BALANCE: true,
-      }),
+      })
+    );
+
+  if (couponOnboarding)
+    adaptersWithBankAccess.push(
       entryBank(couponOnboarding, {
         ADD_TO_BALANCE: true,
-      }),
+      })
+    );
+
+  if (financing)
+    adaptersWithBankAccess.push(
       entryBank(financing, {
         ADD_TO_BALANCE: true,
         SUB_FROM_BALANCE: true,
-      }),
+      })
+    );
+
+  if (tribute)
+    adaptersWithBankAccess.push(
       entryBank(tribute, {
         ADD_TO_BALANCE: true,
         REGISTER_NEW_TOKEN: true,
-      }),
+      })
+    );
+
+  if (distribute)
+    adaptersWithBankAccess.push(
       entryBank(distribute, {
         INTERNAL_TRANSFER: true,
-      }),
+      })
+    );
+
+  if (tributeNFT)
+    adaptersWithBankAccess.push(
       entryBank(tributeNFT, {
         ADD_TO_BALANCE: true,
-      }),
-      // Let the unit-token extension to execute internal transfers in the bank as an adapter
+      })
+    );
+
+  if (erc20TokenExtension)
+    // Let the unit-token extension to execute internal transfers in the bank as an adapter
+    adaptersWithBankAccess.push(
       entryBank(erc20TokenExtension, {
         INTERNAL_TRANSFER: true,
-      }),
-    ],
+      })
+    );
+
+  await daoFactory.configureExtension(
+    dao.address,
+    bankExtension.address,
+    adaptersWithBankAccess,
     { from: owner }
   );
+
+  const adaptersWithNFTAccess = [];
+  if (tributeNFT)
+    adaptersWithNFTAccess.push(
+      entryNft(tributeNFT, {
+        COLLECT_NFT: true,
+      })
+    );
+
+  if (nftAdapter)
+    adaptersWithNFTAccess.push(
+      entryNft(nftAdapter, {
+        COLLECT_NFT: true,
+      })
+    );
 
   await daoFactory.configureExtension(
     dao.address,
     nftExtension.address,
-    [
-      entryNft(tributeNFT, {
-        COLLECT_NFT: true,
-      }),
-      entryNft(nftAdapter, {
-        COLLECT_NFT: true,
-      }),
-    ],
+    adaptersWithNFTAccess,
     {
       from: owner,
     }
@@ -605,51 +698,59 @@ const configureDao = async ({
     { from: owner }
   );
 
-  await onboarding.configureDao(
-    dao.address,
-    UNITS,
-    unitPrice,
-    nbUnits,
-    maxChunks,
-    tokenAddr,
-    {
-      from: owner,
-    }
-  );
+  if (onboarding) {
+    await onboarding.configureDao(
+      dao.address,
+      UNITS,
+      unitPrice,
+      nbUnits,
+      maxChunks,
+      tokenAddr,
+      {
+        from: owner,
+      }
+    );
 
-  await onboarding.configureDao(
-    dao.address,
-    LOOT,
-    unitPrice,
-    nbUnits,
-    maxChunks,
-    tokenAddr,
-    {
-      from: owner,
-    }
-  );
+    await onboarding.configureDao(
+      dao.address,
+      LOOT,
+      unitPrice,
+      nbUnits,
+      maxChunks,
+      tokenAddr,
+      {
+        from: owner,
+      }
+    );
+  }
+  if (couponOnboarding)
+    await couponOnboarding.configureDao(
+      dao.address,
+      couponCreatorAddress,
+      UNITS,
+      {
+        from: owner,
+      }
+    );
 
-  await couponOnboarding.configureDao(
-    dao.address,
-    couponCreatorAddress,
-    UNITS,
-    {
+  if (voting)
+    await voting.configureDao(dao.address, votingPeriod, gracePeriod, {
       from: owner,
-    }
-  );
+    });
 
-  await voting.configureDao(dao.address, votingPeriod, gracePeriod, {
-    from: owner,
-  });
-  await tribute.configureDao(dao.address, UNITS, {
-    from: owner,
-  });
-  await tribute.configureDao(dao.address, LOOT, {
-    from: owner,
-  });
-  await tributeNFT.configureDao(dao.address, {
-    from: owner,
-  });
+  if (tribute) {
+    await tribute.configureDao(dao.address, UNITS, {
+      from: owner,
+    });
+    await tribute.configureDao(dao.address, LOOT, {
+      from: owner,
+    });
+  }
+
+  if (tributeNFT)
+    await tributeNFT.configureDao(dao.address, {
+      from: owner,
+    });
 };
 
 const cloneDao = async ({
@@ -860,6 +961,10 @@ const networks = [
   },
   {
     name: "coverage",
+    chainId: 1,
+  },
+  {
+    name: "mainnet",
     chainId: 1,
   },
 ];

--- a/utils/OZTestUtil.js
+++ b/utils/OZTestUtil.js
@@ -52,7 +52,7 @@ const { expectRevert } = require("@openzeppelin/test-helpers");
 const { expect } = require("chai");
 
 const deployFunction = async (contractInterface, args, from) => {
-  if (!contractInterface) return null;
+  if (!contractInterface) throw Error("Invalid contract interface");
   const f = from ? from : accounts[0];
   if (args) {
     return await contractInterface.new(...args, { from: f });

--- a/utils/TruffleUtil.js
+++ b/utils/TruffleUtil.js
@@ -25,37 +25,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-const { contracts } = require("./ContractUtil");
+const getContractFromTruffle = (c) => {
+  return artifacts.require(c);
+};
 
-const truffleContracts = getContracts();
+const getTruffleContracts = (contracts) => {
+  return contracts
+    .filter((c) => c.enabled)
+    .reduce((previousValue, contract) => {
+      previousValue[contract.name] = getContractFromTruffle(contract.path);
+      return previousValue;
+    }, {});
+};
 
 const deployFunctionFactory = (deployer) => {
   const deployFunction = async (contractInterface, args) => {
-    let result;
+    if (!contractInterface) return null;
     if (args) {
-      result = await deployer.deploy(contractInterface, ...args);
+      await deployer.deploy(contractInterface, ...args);
     } else {
-      result = await deployer.deploy(contractInterface);
+      await deployer.deploy(contractInterface);
     }
-    result = await contractInterface.deployed();
-    return result;
+    return await contractInterface.deployed();
   };
 
   return deployFunction;
 };
 
-function getContractFromTruffle(c) {
-  return artifacts.require(c);
-}
-
-function getContracts() {
-  return Object.keys(contracts).reduce((previousValue, key) => {
-    previousValue[key] = getContractFromTruffle(contracts[key]);
-    return previousValue;
-  }, {});
-}
-
-module.exports = {
-  ...truffleContracts,
-  deployFunctionFactory,
+module.exports = (contracts) => {
+  const truffleContracts = getTruffleContracts(contracts);
+  return { ...truffleContracts, deployFunctionFactory };
 };

--- a/utils/TruffleUtil.js
+++ b/utils/TruffleUtil.js
@@ -66,6 +66,7 @@ const deployFunction = (deployer, daoArtifacts, allContracts) => {
     if (
       // Always deploy core and test contracts
       contractConfig.type === ContractType.Core ||
+      contractConfig.type === ContractType.Extension ||
       contractConfig.type === ContractType.Test
     ) {
       return deploy(contractInterface, args);
@@ -93,9 +94,8 @@ const deployFunction = (deployer, daoArtifacts, allContracts) => {
     const deployedContract = await deploy(contractInterface, args);
 
     if (
-      // Add the new contract to DaoArtifacts, should not store Core & Test contracts
+      // Add the new contract to DaoArtifacts, should not store Core, Extension & Test contracts
       contractConfig.type === ContractType.Factory ||
-      contractConfig.type === ContractType.Extension ||
       contractConfig.type === ContractType.Adapter ||
       contractConfig.type === ContractType.Util
     ) {

--- a/utils/TruffleUtil.js
+++ b/utils/TruffleUtil.js
@@ -53,7 +53,7 @@ const deployFunction = (deployer, daoArtifacts, allContracts) => {
   };
 
   const loadOrDeploy = async (contractInterface, args) => {
-    if (!contractInterface) throw Error("Invalid contract interface");
+    if (!contractInterface) return null; //throw Error("Invalid contract interface");
 
     const contractConfig = allContracts.find(
       (c) => c.name === contractInterface.contractName
@@ -106,7 +106,7 @@ const deployFunction = (deployer, daoArtifacts, allContracts) => {
         contractConfig.type
       );
       console.log(
-        `${contractConfig.type}:${contractConfig.name}:${contractConfig.version}:${deployedContract.address} added to DaoArtifacts`
+        `${contractConfig.name}:${contractConfig.type}:${contractConfig.version}:${deployedContract.address} added to DaoArtifacts`
       );
     }
 

--- a/utils/TruffleUtil.js
+++ b/utils/TruffleUtil.js
@@ -42,7 +42,7 @@ const getTruffleContracts = (contracts) => {
     });
 };
 
-const deployFunctionFactory = (deployer, allContracts) => {
+const deployFunctionFactory = (deployer, daoArtifacts, allContracts) => {
   const deploy = async (contractInterface, args) => {
     console.log("Deploy new contract");
     if (!contractInterface) return null;
@@ -63,9 +63,6 @@ const deployFunctionFactory = (deployer, allContracts) => {
       return deploy(contractConfig, contractInterface, args);
     }
 
-    const daoArtifacts = await DaoArtifacts.at(
-      process.env.DAO_ARTIFACTS_CONTRACT_ADDR
-    );
     const address = await daoArtifacts.getArtifactAddress(
       sha3(contractConfig.name),
       process.env.ARTIFACT_OWNER_ADDR,
@@ -92,8 +89,8 @@ module.exports = (contracts) => {
 
   return {
     ...truffleInterfaces,
-    deployFunctionFactory: (deployer) => {
-      deployFunctionFactory(deployer, allContracts);
+    deployFunctionFactory: (deployer, daoArtifacts) => {
+      deployFunctionFactory(deployer, daoArtifacts, allContracts);
     },
   };
 };

--- a/utils/TruffleUtil.js
+++ b/utils/TruffleUtil.js
@@ -64,7 +64,7 @@ const deployFunction = (deployer, daoArtifacts, allContracts) => {
       );
 
     if (
-      // Always deploy core and test contracts
+      // Always deploy core, extension and test contracts
       contractConfig.type === ContractType.Core ||
       contractConfig.type === ContractType.Extension ||
       contractConfig.type === ContractType.Test

--- a/website/docs/tutorial/adapters/HowToCreateAnAdapter.md
+++ b/website/docs/tutorial/adapters/HowToCreateAnAdapter.md
@@ -247,7 +247,23 @@ There are several examples of tests that you can check to start building your ow
 
 The general idea is to create one test suite per adapter/contract. And try to cover all the happy paths first, and then add more complex test cases after that.
 
-You need to declare the new adapter contract to `ContractUtil.js`, so it can be accessed in the deploy/test environment.
+You need to declare the new adapter contract in `deployment/contracts.config.js` file, so it can be accessed in the deploy/test environment. Make sure you use following the structure:
+
+```json
+{
+    name: "Sample2Contract",
+    path: "../contracts/path/Sample2Contract",
+    enabled: true,
+    version: "1.0.0",
+    type: ContractType.Adapter,
+  },
+```
+
+- `name`: the name of the contract declared in the .sol file;
+- `path`: the path of the contract in the `contracts` folder;
+- `enabled`: the flag indicating if that contract must be deployed/enabled;
+- `version`: the version of the contract that will be used to write/read to/from the `DaoArtifacts` contract;
+- `type`: the type of the contract (Core = 0, Factory = 1, Extension = 2, Adapter = 3, Util = 4, Test = 5).
 
 In order to speed up the test suites we usually don't create one DAO per test function, but we create the DAO during the suite initialization, and only reset the chain after each test function using the chain snapshot feature. For instance:
 

--- a/website/docs/tutorial/extensions/HowToCreateAnExtension.md
+++ b/website/docs/tutorial/extensions/HowToCreateAnExtension.md
@@ -257,7 +257,30 @@ There are several examples of tests that you can check to start building your ow
 
 The general idea is to create one test suite per extension/contract. And try to cover all the happy paths first, and then add more complex and negative test cases after that.
 
-You need to declare the new extension contract to **[ContractUtil.js](https://github.com/openlawteam/tribute-contracts/blob/master/utils/ContractUtil.js)**, so it can be accessed in the deploy/test environment.
+You need to declare the new extension and factory contracts in `deployment/contracts.config.js` file, so both contracts can be accessed in the deploy/test environment. Make sure you use following the structure:
+
+```json
+ {
+    name: "MyExtension",
+    path: "../contracts/path/MyExtension",
+    enabled: true,
+    version: "1.0.0",
+    type: ContractType.Extension,
+  },
+   {
+    name: "MyExtensionFactory",
+    path: "../contracts/path/MyExtensionFactory",
+    enabled: true,
+    version: "1.0.0",
+    type: ContractType.Factory,
+  },
+```
+
+- `name`: the name of the contract declared in the .sol file;
+- `path`: the path of the contract in the `contracts` folder;
+- `enabled`: the flag indicating if that contract must be deployed/enabled;
+- `version`: the version of the contract that will be used to write/read to/from the `DaoArtifacts` contract;
+- `type`: the type of the contract (Core = 0, Factory = 1, Extension = 2, Adapter = 3, Util = 4, Test = 5).
 
 In order to speed up the test suites we usually don't create one DAO per test function, but we create the DAO during the suite initialization, and only reset the chain after each test function using the chain snapshot feature. For instance:
 


### PR DESCRIPTION
Main changes:

1. All contracts must be declared in the `deployment/contracts.config.js` file following the structure:
```json
{
    name: "ContractName",
    path: "../contracts/path/ContractName",
    enabled: true,
    version: "1.0.0",
    type: ContractType.TYPE,
  },
```
- `name`: the name of the contract declared in the .sol file;
- `path`: the path of the contract in the `contracts` folder;
- `enabled`: the flag indicating if that contract must be deployed/enabled;
- `version`: the version of the contract that will be used to write/read to/from the `DaoArtifacts` contract;
- `type`: the type of the contract (Core = 0, Factory = 1, Extension = 2, Adapter = 3, Util = 4, Test = 5)

2. Each contract can be removed from the deployment process, all you need to do is to added the contract name to the corresponding network config file in the `deployment/*.config.js`. Any contract name added to the `disabled` list will be skipped during the deployment. It is useful make sure you deploy only contracts that are really mandatory to your DAO.

3. Added the `Alchemy` url as environment variable for the HD Truffle Wallet in `truffle.config.js`. 

4. Increased the block polling time to reduce rate-limit issues.

5. TruffleUtil was updated to build the deploymentFunctionFactory using the new `DaoArtifacts` contract. If the `DaoArtifacts` address is not provided as environment variables, a new contract gets created and every new Adapter, Factory and Utility contracts gets added to the new `DaoArtifacts` contract, so they can be reused on future deployments. The deploy function for truffle migrate task was updated to attempt to load the contracts by Id, Version, Owner and Type from the `DaoArtifacts` first, if there is a match, that contract gets attached to the new DAO - this approach saves gas during the deployment step because we don't need to create all the Adapters, Factories or Utilities contracts every time. 

6. The owner of the artifacts in the `DaoArtifacts` contract can be specified via environment variable: `DAO_ARTIFACTS_OWNER_ADDR`, if not specified, the `DAO_OWNER_ADDR` will be used as the default owner.

7. The `DaoArtifacts` contract can be specified via environment variable: `DAO_ARTIFACTS_CONTRACT_ADDR`, if none is specified, then a new contract gets deployed.

TODO:
- [x] Mainnet deployment 
- [x] Update docs