### PR TITLE
fix security issue with guild kick

### DIFF
--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -123,7 +123,7 @@ contract GuildKickContract is IGuildKick, MemberGuard, AdapterGuard {
         IVoting votingContract = IVoting(dao.getAdapterAddress(VOTING));
         votingContract.startNewVotingForProposal(dao, proposalId, data);
 
-        GuildKickHelper.prepareRageKick(
+        GuildKickHelper.lockMemberTokens(
             dao,
             kicks[address(dao)][proposalId].memberToKick
         );
@@ -159,7 +159,7 @@ contract GuildKickContract is IGuildKick, MemberGuard, AdapterGuard {
             votingState == IVoting.VotingState.NOT_PASS ||
             votingState == IVoting.VotingState.TIE
         ) {
-            GuildKickHelper.unkickMember(
+            GuildKickHelper.unlockMemberTokens(
                 dao,
                 kicks[address(dao)][proposalId].memberToKick
             );

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -694,7 +694,7 @@ contract OffchainVotingContract is IVoting, MemberGuard, AdapterGuard, Ownable {
             challengeProposalId
         ] = ProposalChallenge(challengedReporter, units);
 
-        GuildKickHelper.prepareRageKick(dao, challengedReporter);
+        GuildKickHelper.lockMemberTokens(dao, challengedReporter);
 
         emit ResultChallenged(
             proposalId,

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -16,6 +16,7 @@ import "./SnapshotProposalContract.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import "../../helpers/GuildKickHelper.sol";
 
 /**
 MIT License
@@ -41,13 +42,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-contract OffchainVotingContract is
-    IVoting,
-    DaoConstants,
-    MemberGuard,
-    AdapterGuard,
-    Ownable
-{
+contract OffchainVotingContract is IVoting, MemberGuard, AdapterGuard, Ownable {
     enum BadNodeError {
         OK,
         WRONG_PROPOSAL_ID,
@@ -71,18 +66,20 @@ contract OffchainVotingContract is
     );
     event ResultChallenged(bytes32 proposalId, bytes32 resultRoot);
 
-    uint256 public constant NB_CHOICES = 2;
+    uint256 private constant NB_CHOICES = 2;
     SnapshotProposalContract private _snapshotContract;
-    OffchainVotingHashContract public ovHash;
+    OffchainVotingHashContract private ovHash;
     KickBadReporterAdapter private _handleBadReporterAdapter;
 
-    string public constant ADAPTER_NAME = "OffchainVotingContract";
-    bytes32 constant VotingPeriod = keccak256("offchainvoting.votingPeriod");
-    bytes32 constant GracePeriod = keccak256("offchainvoting.gracePeriod");
-    bytes32 constant FallbackThreshold =
+    string private constant ADAPTER_NAME = "OffchainVotingContract";
+    bytes32 private constant VotingPeriod =
+        keccak256("offchainvoting.votingPeriod");
+    bytes32 private constant GracePeriod =
+        keccak256("offchainvoting.gracePeriod");
+    bytes32 private constant FallbackThreshold =
         keccak256("offchainvoting.fallbackThreshold");
 
-    mapping(bytes32 => mapping(uint256 => uint256)) retrievedStepsFlags;
+    mapping(bytes32 => mapping(uint256 => uint256)) private retrievedStepsFlags;
 
     struct Voting {
         uint256 snapshot;
@@ -104,10 +101,11 @@ contract OffchainVotingContract is
         _;
     }
 
-    VotingContract public fallbackVoting;
+    VotingContract private fallbackVoting;
 
-    mapping(address => mapping(bytes32 => ProposalChallenge)) challengeProposals;
-    mapping(address => mapping(bytes32 => Voting)) public votes;
+    mapping(address => mapping(bytes32 => ProposalChallenge))
+        private challengeProposals;
+    mapping(address => mapping(bytes32 => Voting)) private votes;
 
     constructor(
         VotingContract _c,
@@ -605,7 +603,7 @@ contract OffchainVotingContract is
         bytes32 proposalId,
         OffchainVotingHashContract.VoteResultNode memory nodePrevious,
         OffchainVotingHashContract.VoteResultNode memory nodeCurrent
-    ) external {
+    ) public {
         Voting storage vote = votes[address(dao)][proposalId];
         bytes32 resultRoot = vote.resultRoot;
 
@@ -696,11 +694,7 @@ contract OffchainVotingContract is
             challengeProposalId
         ] = ProposalChallenge(challengedReporter, units);
 
-        // Burns / subtracts from member's balance the number of units to burn.
-        bank.subtractFromBalance(challengedReporter, UNITS, units);
-        // Burns / subtracts from member's balance the number of loot to burn.
-        // bank.subtractFromBalance(memberToKick, LOOT, kick.lootToBurn);
-        bank.addToBalance(challengedReporter, LOOT, units);
+        GuildKickHelper.prepareRageKick(dao, challengedReporter);
 
         emit ResultChallenged(
             proposalId,

--- a/contracts/core/DaoConstants.sol
+++ b/contracts/core/DaoConstants.sol
@@ -52,10 +52,12 @@ abstract contract DaoConstants {
 
     // Reserved Addresses
     address internal constant GUILD = address(0xdead);
-    address internal constant TOTAL = address(0xbabe);
     address internal constant ESCROW = address(0x4bec);
+    address internal constant TOTAL = address(0xbabe);
     address internal constant UNITS = address(0xFF1CE);
+    address internal constant LOCKED_UNITS = address(0xFFF1CE);
     address internal constant LOOT = address(0xB105F00D);
+    address internal constant LOCKED_LOOT = address(0xBB105F00D);
     address internal constant ETH_TOKEN = address(0x0);
     address internal constant MEMBER_COUNT = address(0xDECAFBAD);
 

--- a/contracts/helpers/GuildKickHelper.sol
+++ b/contracts/helpers/GuildKickHelper.sol
@@ -42,7 +42,7 @@ library GuildKickHelper {
     bytes32 internal constant BANK = keccak256("bank");
     address internal constant GUILD = address(0xdead);
 
-    function prepareRageKick(DaoRegistry dao, address potentialKickedMember)
+    function lockMemberTokens(DaoRegistry dao, address potentialKickedMember)
         internal
     {
         // Get the bank extension
@@ -64,7 +64,7 @@ library GuildKickHelper {
         bank.subtractFromBalance(potentialKickedMember, LOOT, lootToBurn);
     }
 
-    function unkickMember(DaoRegistry dao, address kickedMember) internal {
+    function unlockMemberTokens(DaoRegistry dao, address kickedMember) internal {
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
 
         uint256 unitsToReturn = bank.balanceOf(kickedMember, LOCKED_UNITS);

--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -695,6 +695,7 @@ const configureDao = async ({
         INTERNAL_TRANSFER: true,
         SUB_FROM_BALANCE: true,
         ADD_TO_BALANCE: true,
+        REGISTER_NEW_TOKEN: true,
       })
     );
 

--- a/utils/TestUtils.js
+++ b/utils/TestUtils.js
@@ -1,7 +1,7 @@
 // Whole-script strict mode syntax
 "use strict";
 
-const { toBN, UNITS, LOOT } = require("./ContractUtil.js");
+const { toBN, UNITS } = require("./ContractUtil.js");
 
 const { expect, advanceTime } = require("./OZTestUtil.js");
 


### PR DESCRIPTION
Making sure a member can not move the tokens if the guild wants to kick him.

GuildKick: 
- The funds of the member are locked until the guild kick proposal is processed. If it pass, the member is kicked and the locked funds are burned. If it fail, the funds are returned to the member.

Offchain:
- The funds of the challenger are locked until the challenge proposal is processed via KickBadReporterAdapter