### PR TITLE
fix: invalid extension name

### DIFF
--- a/contracts/extensions/erc1155/ERC1155TokenExtensionFactory.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtensionFactory.sol
@@ -29,7 +29,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-contract ERC1155CollectionFactory is CloneFactory, DaoConstants {
+contract ERC1155TokenExtensionFactory is CloneFactory, DaoConstants {
     address public identityAddress;
 
     event ERC1155CollectionCreated(address nftCollAddress);

--- a/deployment/contracts.config.js
+++ b/deployment/contracts.config.js
@@ -119,7 +119,7 @@ const contracts = [
   },
   {
     name: "ERC1155TokenExtensionFactory",
-    path: "../contracts/extensions/erc1155/ERC1155CollectionFactory",
+    path: "../contracts/extensions/erc1155/ERC1155TokenExtensionFactory",
     enabled: true,
     version: "1.0.0",
     type: ContractType.Factory,


### PR DESCRIPTION
The name declared in the contracts.config.js was invalid, so the contract could not be deployed using our deployment script. Just fixed that.