### PR TITLE
feat: add/remove extensions + set extension acl flags

### DIFF
--- a/contracts/adapters/Managing.sol
+++ b/contracts/adapters/Managing.sol
@@ -143,7 +143,7 @@ contract ManagingContract is
                 dao.addExtension(
                     proposal.adapterOrExtensionId,
                     IExtension(proposal.adapterOrExtensionAddr),
-                    msg.sender
+                    dao.getMemberAddress(0)
                 );
             }
         } else {

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -29,19 +29,32 @@ SOFTWARE.
  */
 
 interface IManaging {
+
     struct ProposalInput {
         bytes32 adapterId;
         address adapterAddress;
         uint128 flags;
+        bytes32[] keys;
+        uint256[] values;
+        address[] extensionAddresses;
+        uint256[] extensionAcl;
+    }
+
+    struct ProposalDetails {
+        bytes32 adapterId;
+        address adapterAddress;
+        uint128 flags;
+        bytes32[] keys;
+        uint256[] values;
+        address[] extensionAddresses;
+        uint256[] extensionAcl;
     }
 
     function submitProposal(
         DaoRegistry dao,
         bytes32 proposalId,
-        ProposalInput memory proposal,
-        bytes32[] memory keys,
-        uint256[] memory values,
-        bytes memory data
+        ProposalInput calldata proposal,
+        bytes calldata data
     ) external;
 
     function processProposal(DaoRegistry dao, bytes32 proposalId) external;

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -29,10 +29,12 @@ SOFTWARE.
  */
 
 interface IManaging {
+    enum UpdateType {UNKNOWN, ADAPTER, EXTENSION}
 
     struct ProposalInput {
-        bytes32 adapterId;
-        address adapterAddress;
+        bytes32 id;
+        address addr;
+        UpdateType updateType;
         uint128 flags;
         bytes32[] keys;
         uint256[] values;
@@ -41,8 +43,9 @@ interface IManaging {
     }
 
     struct ProposalDetails {
-        bytes32 adapterId;
-        address adapterAddress;
+        bytes32 id;
+        address addr;
+        UpdateType updateType;
         uint128 flags;
         bytes32[] keys;
         uint256[] values;

--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -31,32 +31,21 @@ SOFTWARE.
 interface IManaging {
     enum UpdateType {UNKNOWN, ADAPTER, EXTENSION}
 
-    struct ProposalInput {
-        bytes32 id;
-        address addr;
-        UpdateType updateType;
-        uint128 flags;
-        bytes32[] keys;
-        uint256[] values;
-        address[] extensionAddresses;
-        uint256[] extensionAcl;
-    }
-
     struct ProposalDetails {
-        bytes32 id;
-        address addr;
+        bytes32 adapterOrExtensionId;
+        address adapterOrExtensionAddr;
         UpdateType updateType;
         uint128 flags;
         bytes32[] keys;
         uint256[] values;
         address[] extensionAddresses;
-        uint256[] extensionAcl;
+        uint128[] extensionAclFlags;
     }
 
     function submitProposal(
         DaoRegistry dao,
         bytes32 proposalId,
-        ProposalInput calldata proposal,
+        ProposalDetails calldata proposal,
         bytes calldata data
     ) external;
 

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -798,28 +798,71 @@ describe("Adapter - Managing", () => {
     // At this point the adapter should be able access the Bank Extension
     // We check that by verifying if the ACL flag in the DAO matches the one
     // submitted in the proposal.
+
+    /**
+     * Bank flags
+     * 0: ADD_TO_BALANCE
+     * 1: SUB_FROM_BALANCE
+     * 2: INTERNAL_TRANSFER
+     * 3: WITHDRAW
+     * 4: REGISTER_NEW_TOKEN
+     * 5: REGISTER_NEW_INTERNAL_TOKEN
+     * 6: UPDATE_TOKEN
+     */
     expect(await dao.getAdapterAddress(newAdapterId)).equal(newAdapterAddress);
     expect(
       await dao.hasAdapterAccessToExtension(
         newAdapterAddress,
         bankExt.address,
-        entryBank(financing, { ADD_TO_BALANCE: true }).flags
+        0 //ADD_TO_BALANCE
       )
     ).equal(true);
     expect(
       await dao.hasAdapterAccessToExtension(
         newAdapterAddress,
         bankExt.address,
-        entryBank(financing, { SUB_FROM_BALANCE: true }).flags
+        1 // SUB_FROM_BALANCE
       )
     ).equal(true);
     expect(
       await dao.hasAdapterAccessToExtension(
         newAdapterAddress,
         bankExt.address,
-        entryBank(financing, { INTERNAL_TRANSFER: true }).flags
+        2 // INTERNAL_TRANSFER
       )
     ).equal(true);
+
+    expect(
+      await dao.hasAdapterAccessToExtension(
+        newAdapterAddress,
+        bankExt.address,
+        3 // WITHDRAW
+      )
+    ).equal(false);
+
+    expect(
+      await dao.hasAdapterAccessToExtension(
+        newAdapterAddress,
+        bankExt.address,
+        4 // REGISTER_NEW_TOKEN
+      )
+    ).equal(false);
+
+    expect(
+      await dao.hasAdapterAccessToExtension(
+        newAdapterAddress,
+        bankExt.address,
+        5 // REGISTER_NEW_INTERNAL_TOKEN
+      )
+    ).equal(false);
+
+    expect(
+      await dao.hasAdapterAccessToExtension(
+        newAdapterAddress,
+        bankExt.address,
+        6 // UPDATE_TOKEN
+      )
+    ).equal(false);
   });
 
   it("should be possible to add a new extension", async () => {

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -98,9 +98,11 @@ describe("Adapter - Managing", () => {
           adapterId: newAdapterId,
           adapterAddress: GUILD,
           flags: 0,
+          keys: ["0x0000000000000000000000000000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000000000000000000000000000002", "0x0000000000000000000000000000000000000000000000000000000000000004"], // 3 keys
+          values: [], // 0 values
+          extensionAddresses:[],
+          extensionAcl:[],
         },
-        ["0x1", "0x2", "0x3"], // 3 keys
-        [], // 0 values
         [],
         { from: daoOwner, gasPrice: toBN("0") }
       ),
@@ -120,9 +122,11 @@ describe("Adapter - Managing", () => {
           adapterId: newAdapterId,
           adapterAddress: GUILD,
           flags: 0,
+          keys: [], // 0 keys
+          values: [1, 2, 3], // 3 values
+          extensionAddresses: [],
+          extensionAcl: []
         },
-        [], // 0 keys
-        [1, 2, 3], // 3 values
         [],
         { from: daoOwner, gasPrice: toBN("0") }
       ),
@@ -142,9 +146,11 @@ describe("Adapter - Managing", () => {
           adapterId: newAdapterId,
           adapterAddress: GUILD,
           flags: 0,
+          keys: [], // 0 keys
+          values: [], // 3 values
+          extensionAddresses: [],
+          extensionAcl: []
         },
-        [],
-        [],
         [],
         { from: daoOwner, gasPrice: toBN("0") }
       ),
@@ -159,9 +165,11 @@ describe("Adapter - Managing", () => {
           adapterId: newAdapterId,
           adapterAddress: TOTAL,
           flags: 0,
+          keys: [], // 0 keys
+          values: [], // 3 values
+          extensionAddresses: [],
+          extensionAcl: []
         },
-        [],
-        [],
         [],
         { from: daoOwner, gasPrice: toBN("0") }
       ),
@@ -183,9 +191,11 @@ describe("Adapter - Managing", () => {
         adapterId: adapterIdToRemove,
         adapterAddress: "0x0000000000000000000000000000000000000000",
         flags: 0,
+        keys: [], // 0 keys
+        values: [], // 3 values
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -230,9 +240,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: newAdapterAddress,
         flags: 0,
+        keys: [], // 0 keys
+        values: [], // 3 values
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       { from: daoOwner, gasPrice: toBN("0") }
     );
@@ -291,9 +303,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: newManaging.address,
         flags: 0,
+        keys: [], 
+        values: [],
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -309,9 +323,11 @@ describe("Adapter - Managing", () => {
           adapterId: newAdapterId,
           adapterAddress: newManaging.address,
           flags: 0,
+          keys: [],
+          values: [], 
+          extensionAddresses: [],
+          extensionAcl: []
         },
-        [],
-        [],
         [],
         {
           from: daoOwner,
@@ -340,9 +356,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: newManaging.address,
         flags,
+        keys: [],
+        values: [], 
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -382,9 +400,11 @@ describe("Adapter - Managing", () => {
         adapterId: sha3("financing"),
         adapterAddress: "0x0000000000000000000000000000000000000000",
         flags: 0,
+        keys: [],
+        values: [], 
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -430,9 +450,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: newManaging.address,
         flags: entryDao("managing", newManaging, {}).flags, // no permissions were set
+        keys: [],
+        values: [], 
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -461,9 +483,11 @@ describe("Adapter - Managing", () => {
           adapterId: sha3("voting"),
           adapterAddress: voting.address,
           flags: 0,
+          keys: [],
+          values: [], 
+          extensionAddresses: [],
+          extensionAcl: []
         },
-        [],
-        [],
         [],
         {
           from: daoOwner,
@@ -490,9 +514,11 @@ describe("Adapter - Managing", () => {
           adapterId: newAdapterId,
           adapterAddress: newAdapterAddress,
           flags: 0,
+          keys: [],
+          values: [], 
+          extensionAddresses: [],
+          extensionAcl: []
         },
-        [],
-        [],
         [],
         { from: nonMember, gasPrice: toBN("0") }
       ),
@@ -516,9 +542,11 @@ describe("Adapter - Managing", () => {
           adapterId: newAdapterId,
           adapterAddress: newVoting.address,
           flags: 0,
+          keys: [],
+          values: [], 
+          extensionAddresses: [],
+          extensionAcl: []
         },
-        [],
-        [],
         [],
         {
           from: nonMemberAddress,
@@ -544,9 +572,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: accounts[6], //any sample address
         flags: 0,
+        keys: [],
+        values: [], 
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -580,9 +610,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: accounts[6], //any sample address
         flags: 0,
+        keys: [],
+        values: [], 
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -619,9 +651,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: "0x0000000000000000000000000000000000000000", // 0ed address to indicate a removal operation
         flags: 0,
+        keys: [],
+        values: [], 
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,
@@ -655,9 +689,11 @@ describe("Adapter - Managing", () => {
         adapterId: newAdapterId,
         adapterAddress: voting.address, // using the voting.address as the new financing adapter address
         flags: 0,
+        keys: [],
+        values: [], 
+        extensionAddresses: [],
+        extensionAcl: []
       },
-      [],
-      [],
       [],
       {
         from: daoOwner,

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -29,6 +29,7 @@ const {
   toWei,
   TOTAL,
   GUILD,
+  ZERO_ADDRESS,
   sha3,
 } = require("../../utils/ContractUtil.js");
 
@@ -44,10 +45,12 @@ const {
   web3,
   DaoRegistryAdapterContract,
   ManagingContract,
+  FinancingContract,
+  ERC1271Extension,
   VotingContract,
 } = require("../../utils/OZTestUtil.js");
 
-const { entryDao } = require("../../utils/DeploymentUtil.js");
+const { entryDao, entryBank } = require("../../utils/DeploymentUtil.js");
 
 const daoOwner = accounts[1];
 const proposalCounter = proposalIdGenerator().generator;
@@ -95,8 +98,8 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x1",
         {
-          id: newAdapterId,
-          addr: GUILD,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: GUILD,
           updateType: 1,
           flags: 0,
           keys: [
@@ -106,7 +109,7 @@ describe("Adapter - Managing", () => {
           ], // 3 keys
           values: [], // 0 values
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
@@ -124,14 +127,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x1",
         {
-          id: newAdapterId,
-          addr: GUILD,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: GUILD,
           updateType: 1,
           flags: 0,
           keys: [], // 0 keys
           values: [1, 2, 3], // 3 values
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
@@ -149,14 +152,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x1",
         {
-          id: newAdapterId,
-          addr: GUILD,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: GUILD,
           updateType: 1,
           flags: 0,
           keys: [], // 0 keys
           values: [], // 3 values
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
@@ -169,14 +172,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x0",
         {
-          id: newAdapterId,
-          addr: TOTAL,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: TOTAL,
           updateType: 1,
           flags: 0,
           keys: [], // 0 keys
           values: [], // 3 values
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
@@ -196,14 +199,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: adapterIdToRemove,
-        addr: "0x0000000000000000000000000000000000000000",
+        adapterOrExtensionId: adapterIdToRemove,
+        adapterOrExtensionAddr: ZERO_ADDRESS,
         updateType: 1,
         flags: 0,
         keys: [], // 0 keys
         values: [], // 3 values
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -246,14 +249,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: newAdapterAddress,
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: newAdapterAddress,
         updateType: 1,
         flags: 0,
         keys: [], // 0 keys
         values: [], // 3 values
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       { from: daoOwner, gasPrice: toBN("0") }
@@ -310,14 +313,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: newManaging.address,
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: newManaging.address,
         updateType: 1,
         flags: 0,
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -331,14 +334,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         proposalId,
         {
-          id: newAdapterId,
-          addr: newManaging.address,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: newManaging.address,
           updateType: 1,
           flags: 0,
           keys: [],
           values: [],
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         {
@@ -365,14 +368,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: newManaging.address,
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: newManaging.address,
         updateType: 1,
         flags,
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -410,14 +413,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       newProposalId,
       {
-        id: sha3("financing"),
-        addr: "0x0000000000000000000000000000000000000000",
+        adapterOrExtensionId: sha3("financing"),
+        adapterOrExtensionAddr: ZERO_ADDRESS,
         updateType: 1,
         flags: 0,
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -447,7 +450,6 @@ describe("Adapter - Managing", () => {
     );
   });
 
-  //FIXME - for some reason the adapter with flag = 0 is able to submit a proposal, but it shouldnt be possible
   it("should not be possible to use an adapter if it is not configured with the permission flags", async () => {
     const dao = this.dao;
     const managing = this.adapters.managing;
@@ -461,14 +463,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: newManaging.address,
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: newManaging.address,
         updateType: 1,
         flags: entryDao("managing", newManaging, {}).flags, // no permissions were set
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -495,14 +497,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         newProposalId,
         {
-          id: sha3("voting"),
-          addr: voting.address,
+          adapterOrExtensionId: sha3("voting"),
+          adapterOrExtensionAddr: voting.address,
           updateType: 1,
           flags: 0,
           keys: [],
           values: [],
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         {
@@ -527,14 +529,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         proposalId,
         {
-          id: newAdapterId,
-          addr: newAdapterAddress,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: newAdapterAddress,
           updateType: 1,
           flags: 0,
           keys: [],
           values: [],
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         { from: nonMember, gasPrice: toBN("0") }
@@ -556,14 +558,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         proposalId,
         {
-          id: newAdapterId,
-          addr: newVoting.address,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: newVoting.address,
           updateType: 1,
           flags: 0,
           keys: [],
           values: [],
           extensionAddresses: [],
-          extensionAcl: [],
+          extensionAclFlags: [],
         },
         [],
         {
@@ -587,14 +589,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: accounts[6], //any sample address
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: accounts[6], //any sample address
         updateType: 1,
         flags: 0,
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -614,6 +616,9 @@ describe("Adapter - Managing", () => {
       from: nonMember,
       gasPrice: toBN("0"),
     });
+
+    const processedFlag = 2;
+    expect(await dao.getProposalFlag(proposalId, processedFlag)).equal(true);
   });
 
   it("should not be possible to process a proposal if the voting did not pass", async () => {
@@ -626,14 +631,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: accounts[6], //any sample address
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: accounts[6], //any sample address
         updateType: 1,
         flags: 0,
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -668,14 +673,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: "0x0000000000000000000000000000000000000000", // 0ed address to indicate a removal operation
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: ZERO_ADDRESS, // 0 address to indicate a removal operation
         updateType: 1,
         flags: 0,
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -707,14 +712,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        id: newAdapterId,
-        addr: voting.address, // using the voting.address as the new financing adapter address
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: voting.address, // using the voting.address as the new financing adapter address
         updateType: 1,
         flags: 0,
         keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: [],
+        extensionAclFlags: [],
       },
       [],
       {
@@ -736,6 +741,232 @@ describe("Adapter - Managing", () => {
         gasPrice: toBN("0"),
       }),
       "adapterAddress already in use"
+    );
+  });
+
+  it("should be possible to add a new adapter and set the acl flags for some extension", async () => {
+    const dao = this.dao;
+    const managing = this.adapters.managing;
+    const voting = this.adapters.voting;
+    const financing = await FinancingContract.new();
+    const bankExt = this.extensions.bank;
+
+    const newAdapterId = sha3("testFinancing");
+    const newAdapterAddress = financing.address;
+    const proposalId = getProposalCounter();
+
+    await managing.submitProposal(
+      dao.address,
+      proposalId,
+      {
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: newAdapterAddress,
+        updateType: 1,
+        flags: 0,
+        keys: [],
+        values: [],
+        // Set the extension address which will be accessed by the new adapter
+        extensionAddresses: [bankExt.address],
+        // Set the acl flags so the new adapter can access the bank extension
+        extensionAclFlags: [
+          entryBank(financing, {
+            ADD_TO_BALANCE: true,
+            SUB_FROM_BALANCE: true,
+            INTERNAL_TRANSFER: true,
+          }).flags,
+        ],
+      },
+      [],
+      {
+        from: daoOwner,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    await advanceTime(1000);
+
+    await managing.processProposal(dao.address, proposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    // At this point the adapter should be able access the Bank Extension
+    // We check that by verifying if the ACL flag in the DAO matches the one
+    // submitted in the proposal.
+    expect(await dao.getAdapterAddress(newAdapterId)).equal(newAdapterAddress);
+    expect(
+      await dao.hasAdapterAccessToExtension(
+        newAdapterAddress,
+        bankExt.address,
+        entryBank(financing, { ADD_TO_BALANCE: true }).flags
+      )
+    ).equal(true);
+    expect(
+      await dao.hasAdapterAccessToExtension(
+        newAdapterAddress,
+        bankExt.address,
+        entryBank(financing, { SUB_FROM_BALANCE: true }).flags
+      )
+    ).equal(true);
+    expect(
+      await dao.hasAdapterAccessToExtension(
+        newAdapterAddress,
+        bankExt.address,
+        entryBank(financing, { INTERNAL_TRANSFER: true }).flags
+      )
+    ).equal(true);
+  });
+
+  it("should be possible to add a new extension", async () => {
+    const dao = this.dao;
+    const managing = this.adapters.managing;
+    const voting = this.adapters.voting;
+    const erc1171Ext = await ERC1271Extension.new();
+
+    const newExtensionId = sha3("testNewExtension");
+    const newExtensionAddr = erc1171Ext.address;
+    const proposalId = getProposalCounter();
+
+    await managing.submitProposal(
+      dao.address,
+      proposalId,
+      {
+        adapterOrExtensionId: newExtensionId,
+        adapterOrExtensionAddr: newExtensionAddr,
+        updateType: 2, // 1 = Adapter, 2 = Extension
+        flags: 0,
+        keys: [],
+        values: [],
+        // Set the extension address which will be accessed by the new adapter
+        extensionAddresses: [],
+        // Set the acl flags so the new adapter can access the bank extension
+        extensionAclFlags: [],
+      },
+      [],
+      {
+        from: daoOwner,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    await advanceTime(1000);
+
+    await managing.processProposal(dao.address, proposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    expect(await dao.getExtensionAddress(newExtensionId)).equal(
+      newExtensionAddr
+    );
+  });
+
+  it("should be possible to remove an extension", async () => {
+    const dao = this.dao;
+    const managing = this.adapters.managing;
+    const voting = this.adapters.voting;
+    const bankExt = this.extensions.bank;
+
+    const removeExtensionId = sha3("bank");
+    // Use 0 address to indicate we don't want to add, it is just a removal
+    const removeExtensionAddr = ZERO_ADDRESS;
+    const proposalId = getProposalCounter();
+
+    await managing.submitProposal(
+      dao.address,
+      proposalId,
+      {
+        adapterOrExtensionId: removeExtensionId,
+        adapterOrExtensionAddr: removeExtensionAddr,
+        updateType: 2, // 1 = Adapter, 2 = Extension
+        flags: 0,
+        keys: [],
+        values: [],
+        // Set the extension address which will be accessed by the new adapter
+        extensionAddresses: [],
+        // Set the acl flags so the new adapter can access the bank extension
+        extensionAclFlags: [],
+      },
+      [],
+      {
+        from: daoOwner,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    await advanceTime(1000);
+
+    await managing.processProposal(dao.address, proposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    await expectRevert(
+      dao.getExtensionAddress(removeExtensionAddr),
+      "extension not found"
+    );
+  });
+
+  it("should revert if UpdateType is unknown", async () => {
+    const dao = this.dao;
+    const managing = this.adapters.managing;
+    const voting = this.adapters.voting;
+
+    const removeExtensionId = sha3("bank");
+    // Use 0 address to indicate we don't want to add, it is just a removal
+    const removeExtensionAddr = ZERO_ADDRESS;
+    const proposalId = getProposalCounter();
+
+    await managing.submitProposal(
+      dao.address,
+      proposalId,
+      {
+        adapterOrExtensionId: removeExtensionId,
+        adapterOrExtensionAddr: removeExtensionAddr,
+        updateType: 0, //0 = Unknown 1 = Adapter, 2 = Extension
+        flags: 0,
+        keys: [],
+        values: [],
+        // Set the extension address which will be accessed by the new adapter
+        extensionAddresses: [],
+        // Set the acl flags so the new adapter can access the bank extension
+        extensionAclFlags: [],
+      },
+      [],
+      {
+        from: daoOwner,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    await advanceTime(1000);
+
+    await expectRevert(
+      managing.processProposal(dao.address, proposalId, {
+        from: daoOwner,
+        gasPrice: toBN("0"),
+      }),
+      "unknown update type"
     );
   });
 });

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -95,13 +95,18 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x1",
         {
-          adapterId: newAdapterId,
-          adapterAddress: GUILD,
+          id: newAdapterId,
+          addr: GUILD,
+          updateType: 1,
           flags: 0,
-          keys: ["0x0000000000000000000000000000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000000000000000000000000000002", "0x0000000000000000000000000000000000000000000000000000000000000004"], // 3 keys
+          keys: [
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000000000000000000000000000002",
+            "0x0000000000000000000000000000000000000000000000000000000000000004",
+          ], // 3 keys
           values: [], // 0 values
-          extensionAddresses:[],
-          extensionAcl:[],
+          extensionAddresses: [],
+          extensionAcl: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
@@ -119,13 +124,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x1",
         {
-          adapterId: newAdapterId,
-          adapterAddress: GUILD,
+          id: newAdapterId,
+          addr: GUILD,
+          updateType: 1,
           flags: 0,
           keys: [], // 0 keys
           values: [1, 2, 3], // 3 values
           extensionAddresses: [],
-          extensionAcl: []
+          extensionAcl: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
@@ -143,18 +149,19 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x1",
         {
-          adapterId: newAdapterId,
-          adapterAddress: GUILD,
+          id: newAdapterId,
+          addr: GUILD,
+          updateType: 1,
           flags: 0,
           keys: [], // 0 keys
           values: [], // 3 values
           extensionAddresses: [],
-          extensionAcl: []
+          extensionAcl: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
       ),
-      "adapter address is reserved address"
+      "address is reserved"
     );
 
     await expectRevert(
@@ -162,18 +169,19 @@ describe("Adapter - Managing", () => {
         dao.address,
         "0x0",
         {
-          adapterId: newAdapterId,
-          adapterAddress: TOTAL,
+          id: newAdapterId,
+          addr: TOTAL,
+          updateType: 1,
           flags: 0,
           keys: [], // 0 keys
           values: [], // 3 values
           extensionAddresses: [],
-          extensionAcl: []
+          extensionAcl: [],
         },
         [],
         { from: daoOwner, gasPrice: toBN("0") }
       ),
-      "adapter address is reserved address"
+      "address is reserved"
     );
   });
 
@@ -188,13 +196,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: adapterIdToRemove,
-        adapterAddress: "0x0000000000000000000000000000000000000000",
+        id: adapterIdToRemove,
+        addr: "0x0000000000000000000000000000000000000000",
+        updateType: 1,
         flags: 0,
         keys: [], // 0 keys
         values: [], // 3 values
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -237,13 +246,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: newAdapterAddress,
+        id: newAdapterId,
+        addr: newAdapterAddress,
+        updateType: 1,
         flags: 0,
         keys: [], // 0 keys
         values: [], // 3 values
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       { from: daoOwner, gasPrice: toBN("0") }
@@ -300,13 +310,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: newManaging.address,
+        id: newAdapterId,
+        addr: newManaging.address,
+        updateType: 1,
         flags: 0,
-        keys: [], 
+        keys: [],
         values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -320,13 +331,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         proposalId,
         {
-          adapterId: newAdapterId,
-          adapterAddress: newManaging.address,
+          id: newAdapterId,
+          addr: newManaging.address,
+          updateType: 1,
           flags: 0,
           keys: [],
-          values: [], 
+          values: [],
           extensionAddresses: [],
-          extensionAcl: []
+          extensionAcl: [],
         },
         [],
         {
@@ -353,13 +365,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: newManaging.address,
+        id: newAdapterId,
+        addr: newManaging.address,
+        updateType: 1,
         flags,
         keys: [],
-        values: [], 
+        values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -397,13 +410,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       newProposalId,
       {
-        adapterId: sha3("financing"),
-        adapterAddress: "0x0000000000000000000000000000000000000000",
+        id: sha3("financing"),
+        addr: "0x0000000000000000000000000000000000000000",
+        updateType: 1,
         flags: 0,
         keys: [],
-        values: [], 
+        values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -447,13 +461,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: newManaging.address,
+        id: newAdapterId,
+        addr: newManaging.address,
+        updateType: 1,
         flags: entryDao("managing", newManaging, {}).flags, // no permissions were set
         keys: [],
-        values: [], 
+        values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -480,13 +495,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         newProposalId,
         {
-          adapterId: sha3("voting"),
-          adapterAddress: voting.address,
+          id: sha3("voting"),
+          addr: voting.address,
+          updateType: 1,
           flags: 0,
           keys: [],
-          values: [], 
+          values: [],
           extensionAddresses: [],
-          extensionAcl: []
+          extensionAcl: [],
         },
         [],
         {
@@ -511,13 +527,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         proposalId,
         {
-          adapterId: newAdapterId,
-          adapterAddress: newAdapterAddress,
+          id: newAdapterId,
+          addr: newAdapterAddress,
+          updateType: 1,
           flags: 0,
           keys: [],
-          values: [], 
+          values: [],
           extensionAddresses: [],
-          extensionAcl: []
+          extensionAcl: [],
         },
         [],
         { from: nonMember, gasPrice: toBN("0") }
@@ -539,13 +556,14 @@ describe("Adapter - Managing", () => {
         dao.address,
         proposalId,
         {
-          adapterId: newAdapterId,
-          adapterAddress: newVoting.address,
+          id: newAdapterId,
+          addr: newVoting.address,
+          updateType: 1,
           flags: 0,
           keys: [],
-          values: [], 
+          values: [],
           extensionAddresses: [],
-          extensionAcl: []
+          extensionAcl: [],
         },
         [],
         {
@@ -569,13 +587,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: accounts[6], //any sample address
+        id: newAdapterId,
+        addr: accounts[6], //any sample address
+        updateType: 1,
         flags: 0,
         keys: [],
-        values: [], 
+        values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -607,13 +626,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: accounts[6], //any sample address
+        id: newAdapterId,
+        addr: accounts[6], //any sample address
+        updateType: 1,
         flags: 0,
         keys: [],
-        values: [], 
+        values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -648,13 +668,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: "0x0000000000000000000000000000000000000000", // 0ed address to indicate a removal operation
+        id: newAdapterId,
+        addr: "0x0000000000000000000000000000000000000000", // 0ed address to indicate a removal operation
+        updateType: 1,
         flags: 0,
         keys: [],
-        values: [], 
+        values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {
@@ -686,13 +707,14 @@ describe("Adapter - Managing", () => {
       dao.address,
       proposalId,
       {
-        adapterId: newAdapterId,
-        adapterAddress: voting.address, // using the voting.address as the new financing adapter address
+        id: newAdapterId,
+        addr: voting.address, // using the voting.address as the new financing adapter address
+        updateType: 1,
         flags: 0,
         keys: [],
-        values: [], 
+        values: [],
         extensionAddresses: [],
-        extensionAcl: []
+        extensionAcl: [],
       },
       [],
       {

--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -581,6 +581,8 @@ const configureDao = async ({
       entryDao("managing", managing, {
         SUBMIT_PROPOSAL: true,
         REPLACE_ADAPTER: true,
+        ADD_EXTENSION: true,
+        REMOVE_EXTENSION: true,
       })
     );
 

--- a/website/docs/contracts/adapters/configuration/Managing.md
+++ b/website/docs/contracts/adapters/configuration/Managing.md
@@ -3,9 +3,15 @@ id: managing-adapter
 title: Managing
 ---
 
-The Managing adapter handles the proposal creation, sponsorship and processing of a new adapter including its initial configuration, and permissions.
+The Managing adapter handles the proposal creation, sponsorship and processing of a new adapter/extension including its initial configuration, and permissions.
 
-An adapter can be added, removed or replaced in the DAO registry. In order to remove an adapter one must pass the address 0x0 with the adapter id that needs to be removed. In order to add a new adapter one most provide the adapter id, address and access flags. The address of the new adapter can not be a reserved address, and the id must be a known id as defined in the `DaoConstants.sol`. The replace adapter operation removes the adapter from the registry based on the adapter id parameter, and also adds a new adapter using the same id but with a new address.
+An adapter/extension can be added, removed or replaced in the DAO registry. In order to remove an adapter/extension one must pass the address 0x0 with the adapter/extension id that needs to be removed. To add a new adapter/extension one most provide the adapter/extension id, address and access flags. The address of the new adapter/extension can not be a reserved address, and the id must be a known id as defined in the `DaoConstants.sol`. The replace adapter/extension operation removes the adapter/extension from the registry based on the id parameter, and also adds a new adapter/extension using the same id but with a new address.
+
+The Managing adapter also allows one set custom ACL flags to adapters that need to communicate with different extensions.
+
+:::caution
+It is important to indicate which operation type will be performed. Set 1 to `updateType` when you are adding/removing an `Adapter`, and set 2 when you are adding/removing an `Extension`.
+:::
 
 ## Workflow
 
@@ -13,20 +19,19 @@ Submit a proposal and check:
 
 - if caller is an active member
 - if keys and values have equal length
-- if adapter address is valid
+- if adapter/extension address is valid
 - if the access flags don't overflow
-- if adapter address is not reserved
+- if adapter/extension address is not reserved
 
 If all the requirements pass, then the proposal is subitted to registry and the adapter stores the proposal data.
 
-To sponsor a proposal, you need to be an active member, and once sponsored the voting process starts.
+Once the voting period ends, anyone can process the proposal. The proposal is processed only if:
 
-Once the voting period ends, only a member can process the proposal. The proposal is processed only if:
-
-- the caller is an active member
-- the has not been processed already
+- it has not been processed already
 - the proposal has been sponsored
 - the voting has passed
+- the updateType is 1 (adapter) or 2 (extension)
+- the extension `AclFlags`, and `address` are valid
 
 ## Access Flags
 
@@ -34,6 +39,8 @@ Once the voting period ends, only a member can process the proposal. The proposa
 
 - `SUBMIT_PROPOSAL`
 - `REPLACE_ADAPTER`
+- `ADD_EXTENSION`
+- `REMOVE_EXTENSION`
 
 ## Dependencies
 
@@ -45,11 +52,13 @@ Once the voting period ends, only a member can process the proposal. The proposa
 
 ### ProposalDetails
 
-- `adapterId`: The id of the adapter to add, remove or replace.
-- `adapterAddress`: The address of the new adapter contract.
+- `adapterOrExtensionId`: The id of the adapter/extension to add, remove or replace.
+- `adapterOrExtensionAddr`: The contract address of the adapter/extension.
+- `flags`: The DAO ACL for the new adapter.
 - `keys`: The configuration keys for the adapter.
 - `values`: The values to set for the adapter configuration.
-- `flags`: The ACL for the new adapter.
+- `extensionAddresses`: The list of extension addresses that the adapter interacts with.
+- `extensionAclFlags`: The list of ACL flags that the adapter needs to interact with each extension.
 
 ## Storage
 
@@ -69,39 +78,16 @@ All the proposals handled by the adapter per DAO.
      * @dev keys and value must have the same length.
      * @dev proposalId can not be reused.
      * @param dao The dao address.
-     * @param proposalId The guild kick proposal id.
-     * @param adapterId The adapter id to replace, remove or add.
-     * @param adapterAddress The adapter address to add or replace. Use 0x0 if you want to remove the adapter.
-     * @param keys The configuration keys for the adapter.
-     * @param values The values to set for the adapter configuration.
-     * @param _flags The ACL for the new adapter, up to 2**128-1.
+     * @param proposalId Tproposal details
+     * @param proposal The proposal details
+     * @param data Additional data to pass to the voting contract and identify the submitter
      */
     function submitProposal(
         DaoRegistry dao,
         bytes32 proposalId,
-        bytes32 adapterId,
-        address adapterAddress,
-        bytes32[] calldata keys,
-        uint256[] calldata values,
-        uint256 _flags
-    ) external override onlyMember(dao)
-```
-
-### sponsorProposal
-
-```solidity
-    /**
-     * @notice Sponsor a proposal if the proposal id exists.
-     * @dev Only members are allowed to sponsor proposals.
-     * @param dao The dao address.
-     * @param proposalId The guild kick proposal id.
-     * @param data Additional data that can be used for offchain voting validation.
-     */
-    function sponsorProposal(
-        DaoRegistry dao,
-        bytes32 proposalId,
+        ProposalDetails calldata proposal,
         bytes calldata data
-    ) external override onlyMember(dao)
+    ) external override onlyMember(dao) reentrancyGuard(dao)
 ```
 
 ### processProposal
@@ -118,8 +104,7 @@ All the proposals handled by the adapter per DAO.
     function processProposal(DaoRegistry dao, bytes32 proposalId)
         external
         override
-        onlyMember(dao)
-
+        reentrancyGuard(dao)
 ```
 
 ## Events
@@ -134,7 +119,7 @@ When an adapter is removed from the regitry. Event emitted by the DAO Registry.
 
 When a new adapter is added to the registry. Event emitted by the DAO Registry.
 
-- `event AdapterAdded( bytes32 adapterId, address adapterAddress, uint256 flags );`
+- `event AdapterAdded(bytes32 adapterId, address adapterAddress, uint256 flags);`
 
 ### ConfigurationUpdated
 


### PR DESCRIPTION
Updates the `Managing` adapter to allow the addition/removal of extensions, and to set the ACL flags for adapters that need access to different extensions.


TODO:
- [x] I see a FIXME in the managing test. We should check if this is still an issue or not 
- [x] add test that adds an extension
- [x] we need a way to remove an extension too
- [x] update docs