### PR TITLE
feat: updated TributeNFT adapter to safely handle erc1155 and erc721 tokens

### DIFF
--- a/contracts/adapters/ERC1155Adapter.sol
+++ b/contracts/adapters/ERC1155Adapter.sol
@@ -42,24 +42,6 @@ contract ERC1155AdapterContract is DaoConstants, AdapterGuard {
     }
 
     /**
-     * @notice Collects the NFT from the owner and moves to the ERC1155 Token extension address.
-     * @param dao The DAO address.
-     * @param nftAddr The NFT smart contract address.
-     * @param nftTokenId The NFT token id.
-     * @param amount of the nftTokenId.
-     */
-    function collect(
-        DaoRegistry dao,
-        address nftAddr,
-        uint256 nftTokenId,
-        uint256 amount
-    ) external reentrancyGuard(dao) {
-        ERC1155TokenExtension erc1155 =
-            ERC1155TokenExtension(dao.getExtensionAddress(ERC1155_EXT));
-        erc1155.collect(msg.sender, nftAddr, nftTokenId, amount);
-    }
-
-    /**
      * @notice Internally transfers the NFT from one owner to a new owner as long as both are active members.
      * @notice Reverts if the addresses of the owners are not members.
      * @notice Reverts if the fromOwner does not hold the NFT.

--- a/contracts/extensions/erc1155/ERC1155TokenExtension.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtension.sol
@@ -52,7 +52,6 @@ contract ERC1155TokenExtension is
     enum AclFlag {WITHDRAW_NFT, COLLECT_NFT, INTERNAL_TRANSFER}
 
     //EVENTS
-    event CollectedNFT(address nftAddr, uint256 nftTokenId, uint256 amount);
     event TransferredNFT(
         address oldOwner,
         address newOwner,
@@ -80,7 +79,7 @@ contract ERC1155TokenExtension is
     // The (NFT Addr + Token Id) key reverse mapping to track all the tokens collected and actual owners.
     mapping(bytes32 => EnumerableSet.AddressSet) private _ownership;
 
-    // All the NFT addresses collected and stored in the GUILD/Extension collection
+    // All the NFT addresses stored in the Extension collection
     EnumerableSet.AddressSet private _nftAddresses;
 
     //MODIFIERS

--- a/contracts/extensions/erc1155/ERC1155TokenExtension.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtension.sol
@@ -114,33 +114,6 @@ contract ERC1155TokenExtension is
     }
 
     /**
-     * @notice Collects the NFT from the owner and moves it to the NFT extension.
-     * @notice It must be have been allowed to move this token by either {approve} or {setApprovalForAll}.
-     * @dev Reverts if the NFT is not in ERC1155 standard.
-     * @param owner The actual owner of the NFT that will get collected.
-     * @param nftAddr The NFT contract address.
-     * @param nftTokenId The NFT token id.
-     * @param amount The amount of NFT with nftTokenId to be collected.
-     */
-    function collect(
-        address owner,
-        address nftAddr,
-        uint256 nftTokenId,
-        uint256 amount
-    ) external hasExtensionAccess(this, AclFlag.COLLECT_NFT) {
-        IERC1155 erc1155 = IERC1155(nftAddr);
-        erc1155.safeTransferFrom(
-            owner,
-            address(this),
-            nftTokenId,
-            amount,
-            "0x0"
-        );
-        _saveNft(nftAddr, nftTokenId, owner, amount);
-        emit CollectedNFT(nftAddr, nftTokenId, amount);
-    }
-
-    /**
      * @notice Transfers the NFT token from the extension address to the new owner.
      * @notice It also updates the internal state to keep track of the all the NFTs collected by the extension.
      * @notice The caller must have the ACL Flag: WITHDRAW_NFT
@@ -358,25 +331,30 @@ contract ERC1155TokenExtension is
     function onERC1155Received(
         address,
         address,
-        uint256,
-        uint256,
+        uint256 id,
+        uint256 value,
         bytes calldata
-    ) external pure override returns (bytes4) {
+    ) external override returns (bytes4) {
+        _saveNft(msg.sender, id, GUILD, value);
         return this.onERC1155Received.selector;
     }
 
     /**
      *  @notice required function from IERC1155 standard to be able to to batch receive tokens
-     *  @dev this function is currently not supported in this extension and will revert
      */
     function onERC1155BatchReceived(
         address,
         address,
-        uint256[] calldata,
-        uint256[] calldata,
+        uint256[] calldata ids,
+        uint256[] calldata values,
         bytes calldata
-    ) external pure override returns (bytes4) {
-        revert("not supported");
+    ) external override returns (bytes4) {
+        require(ids.length == values.length, "ids values length mismatch");
+        for (uint256 i = 0; i < ids.length; i++) {
+            _saveNft(msg.sender, ids[i], GUILD, values[i]);
+        }
+
+        return this.onERC1155Received.selector;
     }
 
     /**

--- a/test/adapters/tribute-nft.test.js
+++ b/test/adapters/tribute-nft.test.js
@@ -45,6 +45,20 @@ const {
 
 const { onboardingNewMember, isMember } = require("../../utils/TestUtils.js");
 
+const processProposal = (dao, proposalId) =>
+  web3.eth.abi.encodeParameter(
+    {
+      ProcessProposal: {
+        dao: "address",
+        proposalId: "bytes32",
+      },
+    },
+    {
+      dao: dao.address,
+      proposalId,
+    }
+  );
+
 describe("Adapter - TributeNFT", () => {
   const proposalCounter = proposalIdGenerator().generator;
   const daoOwner = accounts[0];
@@ -177,16 +191,16 @@ describe("Adapter - TributeNFT", () => {
 
     await advanceTime(10000);
 
-    // Pre-approve spender (NFT extension) to transfer proposed NFT
-    await pixelNFT.approve(nftExt.address, tokenId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
-
-    await tributeNFT.processProposal(dao.address, proposalId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
+    await pixelNFT.methods["safeTransferFrom(address,address,uint256,bytes)"](
+      nftOwner,
+      tributeNFT.address,
+      tokenId,
+      processProposal(dao, proposalId),
+      {
+        from: nftOwner,
+        gasPrice: toBN("0"),
+      }
+    );
 
     // test balance after proposal is processed
     const applicantUnits = await bank.balanceOf(nftOwner, UNITS);
@@ -203,14 +217,26 @@ describe("Adapter - TributeNFT", () => {
 
   it("should not be possible to process a nft tribute proposal if it does not exist", async () => {
     const proposalId = getProposalCounter();
+    const nftOwner = accounts[2];
     const dao = this.dao;
     const tributeNFT = this.adapters.tributeNFT;
+    const pixelNFT = this.testContracts.pixelNFT;
+
+    await pixelNFT.mintPixel(nftOwner, 1, 1, { from: daoOwner });
+    let pastEvents = await pixelNFT.getPastEvents();
+    let { tokenId } = pastEvents[1].returnValues;
 
     await expectRevert(
-      tributeNFT.processProposal(dao.address, proposalId, {
-        from: daoOwner,
-        gasPrice: toBN("0"),
-      }),
+      pixelNFT.methods["safeTransferFrom(address,address,uint256,bytes)"](
+        nftOwner,
+        tributeNFT.address,
+        tokenId,
+        processProposal(dao, proposalId),
+        {
+          from: nftOwner,
+          gasPrice: toBN("0"),
+        }
+      ),
       "proposal does not exist"
     );
   });
@@ -248,16 +274,16 @@ describe("Adapter - TributeNFT", () => {
 
     await advanceTime(10000);
 
-    // Pre-approve spender (NFT extension) to transfer proposed NFT
-    await pixelNFT.approve(nftExt.address, tokenId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
-
-    await tributeNFT.processProposal(dao.address, proposalId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
+    await pixelNFT.methods["safeTransferFrom(address,address,uint256,bytes)"](
+      nftOwner,
+      tributeNFT.address,
+      tokenId,
+      processProposal(dao, proposalId),
+      {
+        from: nftOwner,
+        gasPrice: toBN("0"),
+      }
+    );
 
     // test balance after proposal is processed
     const applicantUnits = await bank.balanceOf(nftOwner, UNITS);
@@ -325,16 +351,16 @@ describe("Adapter - TributeNFT", () => {
 
     await advanceTime(10000);
 
-    // Pre-approve spender (NFT extension) to transfer proposed NFT
-    await pixelNFT.approve(nftExt.address, tokenId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
-
-    await tributeNFT.processProposal(dao.address, proposalId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
+    await pixelNFT.methods["safeTransferFrom(address,address,uint256,bytes)"](
+      nftOwner,
+      tributeNFT.address,
+      tokenId,
+      processProposal(dao, proposalId),
+      {
+        from: nftOwner,
+        gasPrice: toBN("0"),
+      }
+    );
 
     // test balance after proposal is processed
     const applicantUnits = await bank.balanceOf(nftOwner, UNITS);
@@ -373,17 +399,17 @@ describe("Adapter - TributeNFT", () => {
       { from: daoOwner, gasPrice: toBN("0") }
     );
 
-    // Pre-approve spender (NFT extension) to transfer proposed NFT
-    await pixelNFT.approve(nftExt.address, tokenId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
-
     await expectRevert(
-      tributeNFT.processProposal(dao.address, proposalId, {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }),
+      pixelNFT.methods["safeTransferFrom(address,address,uint256,bytes)"](
+        nftOwner,
+        tributeNFT.address,
+        tokenId,
+        processProposal(dao, proposalId),
+        {
+          from: nftOwner,
+          gasPrice: toBN("0"),
+        }
+      ),
       "proposal has not been voted on"
     );
 
@@ -439,18 +465,18 @@ describe("Adapter - TributeNFT", () => {
 
     await advanceTime(10000);
 
-    // Pre-approve spender (NFT extension) to transfer proposed NFT
-    await pixelNFT.approve(nftExt.address, tokenId, {
-      from: nftOwner,
-      gasPrice: toBN("0"),
-    });
-
     await expectRevert(
-      tributeNFT.processProposal(dao.address, proposalId, {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }),
-      "token amount exceeds the maximum limit for internal tokens."
+      pixelNFT.methods["safeTransferFrom(address,address,uint256,bytes)"](
+        nftOwner,
+        tributeNFT.address,
+        tokenId,
+        processProposal(dao, proposalId),
+        {
+          from: nftOwner,
+          gasPrice: toBN("0"),
+        }
+      ),
+      "token amount exceeds the maximum limit for internal tokens"
     );
   });
 
@@ -491,26 +517,13 @@ describe("Adapter - TributeNFT", () => {
     });
 
     await advanceTime(10000);
-    const processProposal = web3.eth.abi.encodeParameter(
-      {
-        ProcessProposal: {
-          dao: "address",
-          proposalId: "bytes32",
-        },
-      },
-      {
-        dao: dao.address,
-        proposalId,
-      }
-    );
 
-    // Pre-approve spender (NFT extension) to transfer proposed NFT
     await erc1155Token.safeTransferFrom(
       nftOwner,
       tributeNFT.address,
       id,
       3,
-      processProposal,
+      processProposal(dao, proposalId),
       { from: nftOwner }
     );
 
@@ -568,26 +581,13 @@ describe("Adapter - TributeNFT", () => {
     });
 
     await advanceTime(10000);
-    const processProposal = web3.eth.abi.encodeParameter(
-      {
-        ProcessProposal: {
-          dao: "address",
-          proposalId: "bytes32",
-        },
-      },
-      {
-        dao: dao.address,
-        proposalId,
-      }
-    );
 
-    // Pre-approve spender (NFT extension) to transfer proposed NFT
     await erc1155Token.safeTransferFrom(
       nftOwner,
       tributeNFT.address,
       id,
       3,
-      processProposal,
+      processProposal(dao, proposalId),
       { from: nftOwner }
     );
 

--- a/test/extensions/erc1155.test.js
+++ b/test/extensions/erc1155.test.js
@@ -25,7 +25,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-const { toBN, unitPrice, UNITS } = require("../../utils/ContractUtil.js");
+const {
+  toBN,
+  unitPrice,
+  UNITS,
+  GUILD,
+} = require("../../utils/ContractUtil.js");
 
 const {
   takeChainSnapshot,
@@ -120,8 +125,6 @@ describe("Extension - ERC1155", () => {
 
   it("should be possible to collect a NFT if that is allowed", async () => {
     const erc1155TestToken = this.testContracts.erc1155TestToken;
-    const erc1155TestTokenAddress = erc1155TestToken.address;
-
     const nftOwner = accounts[1];
     //create a test 1155 token
     await erc1155TestToken.mint(nftOwner, 1, 10, "0x0", {
@@ -137,30 +140,14 @@ describe("Extension - ERC1155", () => {
 
     //instances for Extension and Adapter
     const erc1155TokenExtension = this.extensions.erc1155Ext;
-    const erc1155Adapter = this.adapters.erc1155Adapter;
 
     //set approval where Extension is the "operator" all of nftOwners
-    await erc1155TestToken.setApprovalForAll(
-      erc1155TokenExtension.address,
-      true,
-      {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }
-    );
-    //check if Extension address is approved
-    const approved = await erc1155TestToken.isApprovedForAll(
+    await erc1155TestToken.safeTransferFrom(
       nftOwner,
-      erc1155TokenExtension.address
-    );
-    expect(approved).equal(true);
-
-    //collect 2 tokens of tokenId 1
-    await erc1155Adapter.collect(
-      this.dao.address,
-      erc1155TestTokenAddress,
-      id,
+      erc1155TokenExtension.address,
+      1,
       2,
+      [],
       {
         from: nftOwner,
         gasPrice: toBN("0"),
@@ -179,145 +166,12 @@ describe("Extension - ERC1155", () => {
 
     //check token balance of the owner = +2 within the extension
     const newGuildBlance = await erc1155TokenExtension.getNFTIdAmount(
-      nftOwner,
+      GUILD,
       erc1155TestToken.address,
       1
     );
 
     expect(newGuildBlance.toString()).equal("2");
-  });
-
-  it("should be possible to do an internal transfer of an NFT from member to another member", async () => {
-    const erc1155TestToken = this.testContracts.erc1155TestToken;
-    const erc1155TestTokenAddress = erc1155TestToken.address;
-
-    const nftOwner = accounts[1];
-    //create a test 1155 token
-    await erc1155TestToken.mint(nftOwner, 1, 10, "0x0", {
-      from: daoOwner,
-      gasPrice: toBN("0"),
-    });
-
-    const pastEvents = await erc1155TestToken.getPastEvents();
-
-    const { id, value } = pastEvents[0].returnValues;
-    expect(id).equal("1");
-    expect(value).equal("10");
-
-    //instances for Extension and Adapter
-    const erc1155TokenExtension = this.extensions.erc1155Ext;
-    const erc1155Adapter = this.adapters.erc1155Adapter;
-
-    //set approval where Extension is the "operator" all of nftOwners
-    await erc1155TestToken.setApprovalForAll(
-      erc1155TokenExtension.address,
-      true,
-      {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }
-    );
-    //check if Extension address is approved
-    const approved = await erc1155TestToken.isApprovedForAll(
-      nftOwner,
-      erc1155TokenExtension.address
-    );
-    expect(approved).equal(true);
-
-    //Onboard members
-    const bank = this.extensions.bank;
-    const onboarding = this.adapters.onboarding;
-    const voting = this.adapters.voting;
-    //onboard applicant A
-    const applicantA = accounts[2];
-    await onboardingNewMember(
-      getProposalCounter(),
-      this.dao,
-      onboarding,
-      voting,
-      applicantA,
-      daoOwner,
-      unitPrice,
-      UNITS,
-      toBN("3")
-    );
-    //check if Applicant A is a member
-    expect(await isMember(bank, applicantA)).equal(true);
-
-    //onboard nftOwner
-    await onboardingNewMember(
-      getProposalCounter(),
-      this.dao,
-      onboarding,
-      voting,
-      nftOwner,
-      daoOwner,
-      unitPrice,
-      UNITS,
-      toBN("3")
-    );
-    //check if nftOwner is a member
-    expect(await isMember(bank, nftOwner)).equal(true);
-
-    //collect 2 tokens of tokenId 1
-    await erc1155Adapter.collect(
-      this.dao.address,
-      erc1155TestTokenAddress,
-      id,
-      2,
-      {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }
-    );
-
-    // Make sure it was collected
-    const nftAddr = await erc1155TokenExtension.getNFTAddress(0);
-    expect(nftAddr).equal(erc1155TestToken.address);
-    const nftId = await erc1155TokenExtension.getNFT(nftAddr, 0);
-    expect(nftId.toString()).equal(id.toString());
-
-    //check token balance of nftOwner account after collection = -2
-    const balanceOfnftOwner = await erc1155TestToken.balanceOf(nftOwner, 1);
-    expect(balanceOfnftOwner.toString()).equal("8");
-
-    //check token balance of nftOwner inside the nftTracker mapping in the Extension = +2
-    const ownerGuildBlance = await erc1155TokenExtension.getNFTIdAmount(
-      nftOwner,
-      erc1155TestToken.address,
-      1
-    );
-
-    expect(ownerGuildBlance.toString()).equal("2");
-
-    //internal transfer from nftOwner to Applicant A of 1 tokenId
-    await erc1155Adapter.internalTransfer(
-      this.dao.address,
-      applicantA,
-      erc1155TestTokenAddress,
-      id,
-      1,
-      {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }
-    );
-
-    //balance check of nftOwner inside the Extension after transfer 2-1 = 1
-    const ownerGuildBalanceAfterInternalTransfer = await erc1155TokenExtension.getNFTIdAmount(
-      nftOwner,
-      erc1155TestToken.address,
-      1
-    );
-    expect(ownerGuildBalanceAfterInternalTransfer.toString()).equal("1");
-
-    //balance check of Applicant A after internal transfer 0 + 1 = 1
-    const applicantABalance = await erc1155TokenExtension.getNFTIdAmount(
-      applicantA,
-      erc1155TestToken.address,
-      1
-    );
-    expect(applicantABalance.toString()).equal("1");
   });
 
   it("should not be possible to do an internal transfer of the NFT to a non member", async () => {
@@ -342,27 +196,12 @@ describe("Extension - ERC1155", () => {
     const erc1155Adapter = this.adapters.erc1155Adapter;
 
     //set approval where Extension is the "operator" all of nftOwners
-    await erc1155TestToken.setApprovalForAll(
-      erc1155TokenExtension.address,
-      true,
-      {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }
-    );
-    //check if Extension address is approved
-    const approved = await erc1155TestToken.isApprovedForAll(
+    await erc1155TestToken.safeTransferFrom(
       nftOwner,
-      erc1155TokenExtension.address
-    );
-    expect(approved).equal(true);
-
-    //collect 2 tokens of tokenId 1
-    await erc1155Adapter.collect(
-      this.dao.address,
-      erc1155TestTokenAddress,
+      erc1155TokenExtension.address,
       id,
       2,
+      [],
       {
         from: nftOwner,
         gasPrice: toBN("0"),
@@ -381,7 +220,7 @@ describe("Extension - ERC1155", () => {
 
     //check token balance of the nftOwner inside the Extension = +2
     const nftOwnerGuildBlance = await erc1155TokenExtension.getNFTIdAmount(
-      nftOwner,
+      GUILD,
       erc1155TestToken.address,
       1
     );
@@ -441,28 +280,12 @@ describe("Extension - ERC1155", () => {
     const erc1155TokenExtension = this.extensions.erc1155Ext;
     const erc1155Adapter = this.adapters.erc1155Adapter;
 
-    //set approval where Extension is the "operator" all of nftOwners
-    await erc1155TestToken.setApprovalForAll(
-      erc1155TokenExtension.address,
-      true,
-      {
-        from: nftOwner,
-        gasPrice: toBN("0"),
-      }
-    );
-    //check if Extension address is approved
-    const approved = await erc1155TestToken.isApprovedForAll(
+    await erc1155TestToken.safeTransferFrom(
       nftOwner,
-      erc1155TokenExtension.address
-    );
-    expect(approved).equal(true);
-
-    //collect 2 tokens of tokenId 1
-    await erc1155Adapter.collect(
-      this.dao.address,
-      erc1155TestTokenAddress,
+      erc1155TokenExtension.address,
       id,
       2,
+      [],
       {
         from: nftOwner,
         gasPrice: toBN("0"),
@@ -481,7 +304,7 @@ describe("Extension - ERC1155", () => {
 
     //check token balance of the nftOwner inside the Extension = +2
     const nftOwnerGuildBlance = await erc1155TokenExtension.getNFTIdAmount(
-      nftOwner,
+      GUILD,
       erc1155TestToken.address,
       1
     );

--- a/website/docs/contracts/adapters/onboarding/TributeNFT.md
+++ b/website/docs/contracts/adapters/onboarding/TributeNFT.md
@@ -71,6 +71,13 @@ Upon processing, if the vote has failed (i.e., more NO votes then YES votes or a
 - `tributeAmount`: The amount of nftTokenId for ERC1155 tokens, if 0, it is an ERC721.
 - `requestAmount`: The amount requested of DAO internal tokens (UNITS).
 
+### ProcessProposal
+
+This struct is used to pass as data when we send the NFT or ERC1155 token to the adapter
+
+- `dao`the dao registry address
+- `proposalId` the proposal Id
+
 ### proposals
 
 All tribute NFT proposals handled by each DAO.
@@ -127,49 +134,34 @@ All tribute NFT proposals handled by each DAO.
     ) external reentrancyGuard(dao)
 ```
 
-### processProposal
+### onERC721Received
 
 ```solidity
-   /**
-     * @notice Processes the proposal to handle minting and exchange of DAO internal tokens for tribute token (passed vote).
-     * @dev Proposal id must exist.
-     * @dev Only proposals that have not already been processed are accepted.
-     * @dev Only sponsored proposals with completed voting are accepted.
-     * @dev The owner of the ERC-721 or ERC-1155 token provided as tribute must first separately `approve` the NFT extension as spender of that token (so the NFT can be transferred for a passed vote).
-     * @param dao The DAO address.
-     * @param proposalId The proposal id.
-     */
-    function processProposal(DaoRegistry dao, bytes32 proposalId)
-        external
-        reentrancyGuard(dao)
-```
-
-### \_hasERC1155TokenBalance
-
-```solidity
-    /**
-     * @notice Validates the balance of the ERC1155 token
-     */
-    function _hasERC1155TokenBalance(
-        address owner,
-        address token,
+function onERC721Received(
+        address operator,
+        address from,
         uint256 tokenId,
-        uint256 balance
-    ) internal view returns (bool)
+        bytes calldata data
+    )
 ```
 
-### \_hasERC721Token
+This function is called by the ERC-721 smart contract after an NFT has been transfered to the adapter. It is used to process the proposal.
+in data, you need to pass the encoded version of the struct ProcessProposal
+
+### onERC1155Received
 
 ```solidity
-    /**
-     * @notice Validates the owner of the ERC721 token
-     */
-    function _hasERC721Token(
-        address owner,
-        address token,
-        uint256 tokenId
-    ) internal view returns (bool)
+function onERC1155Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        uint256 value,
+        bytes calldata data
+    )
 ```
+
+This function is called by the ERC-1155 smart contract after an NFT has been transfered to the adapter. It is used to process the proposal.
+in data, you need to pass the encoded version of the struct ProcessProposal
 
 ## Events
 

--- a/website/docs/contracts/extensions/ERC1155.md
+++ b/website/docs/contracts/extensions/ERC1155.md
@@ -9,7 +9,6 @@ In other words, the DAO becomes capable of managing and curating a collection of
 
 ## Access Flags
 
-- `COLLECT_NFT`: Allows the caller adapter to transfer the NFT to the GUILD collection.
 - `WITHDRAW_NFT`: Allows the caller to remove the NFT from the GUILD collection and return it to a new owner.
 - `INTERNAL_TRANSFER`: Allows the caller to update the internal ownership of the NFT within the GUILD collection.
 


### PR DESCRIPTION
Instead of implementing our own way of signaling whether we work with erc1155 or 721, it uses the standard to do send action which is cleaner, more secure and also reduces the amount of transactions.

I've also removed the ownership check on submission because it should not be a requirement. It is ok to start a proposal and only move the NFT once the proposal has passed

Another important point, erc1155.collect was making the sender the owner instead of GUILD. That meant that anyone could still use the NFT after they gave it as tribute which is not what we want