### PR TITLE
docs: enhancements for the dao tutorial

### DIFF
--- a/website/docs/tutorial/dao/Configuration.md
+++ b/website/docs/tutorial/dao/Configuration.md
@@ -8,10 +8,11 @@ title: Configuration
 ## Requirements
 
 - **[Infura Ethereum API KEY](https://infura.io/product/ethereum)**: sign up for free, verify your email, create an ethereum project to get your API Key (also known as `Project Id`). We will use that to deploy the contracts to the Rinkeby network. Checkout this **[Infura Blog Post](https://blog.infura.io/getting-started-with-infura-28e41844cc89/)** for more info on that.
-- **[The Graph API Access Token](https://thegraph.com/)**: sign up to https://thegraph.com with your Github account, access the **[dashboard](https://thegraph.com/explorer/dashboard)**, and copy the **Access Token**. We will use that to deploy the **[Tribute DAO Subgraph](/docs/subgraph/definition)** to thegraph.com. Then click on "Add Subgraph" and type: _Tribute DAO Tutorial_, give it any subtitle, and hit _Create subgraph_.
-  :::caution
-  Be sure you are adding a subgraph in the legacy version of The Graph! You should see `legacy-explorer` in the URL.
-  :::
+- **[The Graph API Access Token](https://thegraph.com/legacy-explorer/dashboard/)**: sign up to https://thegraph.com/legacy-explorer/dashboard with your Github account, access the **[dashboard](https://thegraph.com/explorer/dashboard)**, and copy the **Access Token**. We will use that to deploy the **[Tribute DAO Subgraph](/docs/subgraph/definition)** to thegraph.com. Then click on "Add Subgraph" and type: _Tribute DAO Tutorial_, give it any subtitle, and hit _Create subgraph_.
+
+:::caution
+Be sure you are adding a subgraph in the **legacy** version of The Graph! You should see `legacy-explorer` in the URL (https://thegraph.com/legacy-explorer/dashboard).
+:::
 
 ## Configuring the project
 
@@ -19,7 +20,7 @@ title: Configuration
 
 ### Environment Variables
 
-The first step is to create a `.env` file in the root of the project directory:
+The first step is to create a `.env` file in the root of the _tribute-contracts_ directory:
 
 ```bash
 touch .env
@@ -62,6 +63,8 @@ INFURA_KEY=
 TRUFFLE_MNEMONIC=...
 
 # The Graph API Access Token that will be used to deploy the Subgraph.
+# Copy the access token from the subgraph project you have created.
+# https://thegraph.com/legacy-explorer/dashboard
 GRAPH_ACCESS_TOKEN=...
 ```
 

--- a/website/docs/tutorial/dao/Installation.md
+++ b/website/docs/tutorial/dao/Installation.md
@@ -29,11 +29,11 @@ tribute-tutorial
 │       │   .env
 │       │   ...
 │
-└───tribute-ui (branch )
+└───tribute-ui
 │     │   .env
 │     │   ...
 │
-└───snapshot-hub (branch )
+└───snapshot-hub (branch erc-712)
     │   .env
     │   docker-compose.yml
     │   ...

--- a/website/docs/tutorial/dao/Installation.md
+++ b/website/docs/tutorial/dao/Installation.md
@@ -16,10 +16,39 @@ sidebar_position: 2
 
 The easiest way to start with TributeDAO Framework is to use the command line tool to clone the Github repository and install all the project dependencies.
 
-Clone and access the Github repo:
+We will use several projects to build and run the TributeDAO in your local environment, so please try to keep the following folder structure:
+
+```
+tribute-tutorial
+│
+└───tribute-contracts (branch v1.0.0)
+│   │   .env
+│   │   ...
+|   |
+│   └───subgraph (branch v1.1.0)
+│       │   .env
+│       │   ...
+│
+└───tribute-ui (branch )
+│     │   .env
+│     │   ...
+│
+└───snapshot-hub (branch )
+    │   .env
+    │   docker-compose.yml
+    │   ...
+```
+
+Create and access the tutorial folder:
 
 ```bash
-git clone git@github.com:openlawteam/tribute-contracts.git && cd tribute-contracts
+mkdir tribute-tutorial && cd tribute-tutorial
+```
+
+Clone and access the _tribute-contracts_ Github repo:
+
+```bash
+git clone https://github.com/openlawteam/tribute-contracts.git && cd tribute-contracts
 ```
 
 :::caution

--- a/website/docs/tutorial/dao/TributeUI.md
+++ b/website/docs/tutorial/dao/TributeUI.md
@@ -8,7 +8,7 @@ title: Tribute UI
 ## Requirements
 
 - **[Infura Ethereum API KEY](https://infura.io/product/ethereum)**, you can use the same key you created in the **[Configuration step](/docs/tutorial/dao/configuration#requirements)** of the tutorial.
-- **[The Graph API Access Token](https://thegraph.com/)**, you need to use the Access Token created in the **[Configuration step](/docs/tutorial/dao/configuration#requirements)** of the tutorial.
+- **[The Graph API Access Token](https://thegraph.com/legacy-explorer/dashboard)**, you need to use the Access Token created in the **[Configuration step](/docs/tutorial/dao/configuration#requirements)** of the tutorial.
 - **[Snapshot Hub ERC712 Service](https://github.com/openlawteam/snapshot-hub/tree/erc-712)** to manage the offchain voting.
 - **[Alchemy API Access Token](https://www.alchemy.com/)** you can sign up to https://www.alchemy.com, create an App called _Tribute DAO Tutorial_, select _Rinkeby_ as default network, and finsh the creation process to get the integration URL.
 - **[Docker Compose](https://docs.docker.com/compose/install/)** install Docker Compose (https://docs.docker.com/compose/install/). This will be used in this tutorial to launch the snapshot-hub service.
@@ -18,18 +18,19 @@ title: Tribute UI
 
 Use the command line tool to clone the Github repository and install all the project dependencies.
 
-Clone and access the Github repo:
+First, make sure you are in the root of _tribute-tutorial_ folder.
+
+Then clone and access the _tribute-ui_ Github repo:
 
 ```bash
-git clone git@github.com:openlawteam/tribute-ui.git
+git clone https://github.com/openlawteam/tribute-ui.git && cd tribute-ui
 ```
 
 ## Configure the environment
 
-After you cloned the Tribute UI repo, let's set up the environment variables, and deploy the subgraph.
+After you cloned the Tribute UI repo, let's set up the environment variables in the root of _tribute-ui_ folder, and deploy the subgraph.
 
 ```bash
-cd tribute-ui
 touch .env
 ```
 
@@ -58,8 +59,13 @@ REACT_APP_SNAPSHOT_SPACE=tribute
 # The url of the subgraph running locally in a container.
 REACT_APP_GRAPH_API_URL=https://api.thegraph.com/subgraphs/name/<GITHUB_USERNAME>/tribute-dao-tutorial
 
+# Make sure it is set to development mode
 REACT_APP_ENVIRONMENT=development
 ```
+
+:::caution
+Please do not change the REACT_APP_SNAPSHOT_SPACE, keep it as is, so it will work with the snapshot-hub service.
+:::
 
 Open the Rinkeby deployment logs, scroll to the end of the file and you should see an output like this:
 
@@ -77,17 +83,20 @@ Then set your Github username to _<GITHUB_USERNAME>_ in **REACT_APP_GRAPH_API_UR
 
 ## Deploy the Subgraph
 
-Go to the `tribute-contracts` root directory and check out the the tag [v1.1.0](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.1.0) which is the version that contains the subgraph that works with [TributeUI](https://github.com/openlawteam/tribute-ui):
+:::caution
+You need to checkout branch v1.1.0 of _tribute-contracts_ to make it work with the tribute-ui.
+:::
+
+Go to the `tribute-tutorial/tribute-contracts` directory and check out the the tag [v1.1.0](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.1.0) which is the version that contains the subgraph that works with [TributeUI](https://github.com/openlawteam/tribute-ui):
 
 ```bash
 cd ../tribute-contracts
-git checkout tags/v1.1.0 -b branch-v1.1.0
 ```
 
-Then install the project dependencies:
+Then checkout the correct branch _v1.1.0_, install the project dependencies:
 
 ```bash
-npm ci
+git checkout tags/v1.1.0 -b branch-v1.1.0 && npm ci
 ```
 
 Access the `subgraph` folder in `tribute-contracts`:
@@ -115,16 +124,30 @@ In the rinkeby deployment logs at _tribute-contracts/logs/rinkeby-deploy.log_ se
 Finally, set your Github username to **GITHUB_USERNAME**, it must be the same Github account that you used to connect to thegraph.com.
 
 :::caution
-The **SUBGRAPH_NAME** should be lowercase and any spaces should be hyphenated, it needs to match the subgraph slug you picked when you created the subgraph in thegraph.com. If you're not sure, go to the [Subgraph Studio](https://thegraph.com/studio/subgraph), navigate to your subgraph, and look for "subgraph slug."
+The **SUBGRAPH_NAME** should be lowercase and any spaces should be hyphenated, it needs to match the subgraph slug you picked when you created the subgraph in thegraph.com. If you're not sure, go to the [Subgraph Legacy Explorer](https://thegraph.com/legacy-explorer/dashboard), navigate to your subgraph, and look for "subgraph slug." or once you click on your subgraph, copy the slug from the browser URL. You should see something like: https://thegraph.com/legacy-explorer/subgraph/[your-github-user]/[slug].
 :::
 
-From the `subgraph` folder, install the dependencies:
+From the `tribute-tutorial/tribute-contracts/subgraph` folder, install the dependencies using Node v14.x:
 
 ```bash
 npm ci
 ```
 
-And start the Subgraph deployment:
+Create the **.env** file under the _subgraph_ folder:
+
+```bash
+touch .env
+```
+
+Add the subgraph API access token:
+
+```bash
+# The Graph API Access Token that will be used to deploy the Subgraph.
+# Copy the Access Token from: https://thegraph.com/legacy-explorer/dashboard
+GRAPH_ACCESS_TOKEN=
+```
+
+Start the Subgraph deployment:
 
 ```bash
 npx ts-node subgraph-deployer.ts
@@ -150,18 +173,18 @@ Subscriptions (WS): wss://api.thegraph.com/subgraphs/name/<your-github-username>
 ## Launch the Snapshot Hub ERC712 service
 
 Use the command line tool to clone the Github repository and launch the docker container.
-This can be done in any directory.
+This can be done in any directory, but to keep it consistent let's checkout the project from the _tribute-tutorial_ folder.
 
-Clone and access the Github repo:
+Clone and access the _snapshot-hub_ Github repo:
 
 ```bash
-git clone git@github.com:openlawteam/snapshot-hub.git
+git clone https://github.com/openlawteam/snapshot-hub.git && cd snapshot-hub
 ```
 
 Checkout the correct branch and create the _.env.local_ file:
 
 ```bash
-cd snapshot-hub && git fetch origin erc-712 && git checkout erc-712 && touch .env.local
+git fetch origin erc-712 && git checkout erc-712 && touch .env.local
 ```
 
 Copy the following content to the new _.env.local_ file:


### PR DESCRIPTION
Added some enhancements to the Launch your DAO tutorial based on the feedback of the community.

- [x] defined a basic folder structure for the tutorial
  -  tribute-tutorial
      - tribute-contracts
	     - subgraph
      - tribute-ui
      - snapshot-hub
- [x] Added the url to the correct thegraph.com, so we can add the subgraph to the legacy api
	- https://thegraph.com/legacy-explorer/dashboard
	
- [x] Added info about installing the tribute-contracts libs after the checkout of branch v1.1.0, and only then install the subgraph libs
- [x] Added the info about the .env file in the subgraph folder with the graph access token
- [x] Added info about using node 14 to build the subgraph
- [x] Added warning to do not change the space name in the tribute-ui  .env
