### PR TITLE
feat: using node url instead of infura key

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Added the following environment variables to your local .env file:
 
 - `DAO_NAME`: The name of the DAO.
 - `DAO_OWNER_ADDR`: The DAO Owner ETH Address (0x...) in the target network.
-- `INFURA_KEY`: The Infura API Key is used to communicate with the Ethereum blockchain.
+- `ETH_NODE_URL`: The Ethereum Node URL to connect to the Ethereum blockchain, it can be http/ws.
 - `TRUFFLE_MNEMONIC`: The truffle mnemonic string containing the 12 keywords.
 - `ETHERSCAN_API_KEY`: The Ether Scan API Key to verify the contracts after the deployment.
 - `DEBUG_CONTRACT_VERIFICATION`: Debug the Ether Scan contract verification calls (`true`|`false`).
@@ -149,9 +149,9 @@ Checkout the [sample .env file](https://github.com/openlawteam/tribute-contracts
 
 - Test deployment: `DAO_NAME`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`.
 
-- Rinkeby deployment: `DAO_NAME`, `DAO_OWNER_ADDR`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`, `COUPON_CREATOR_ADDR`.
+- Rinkeby deployment: `DAO_NAME`, `DAO_OWNER_ADDR`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`, `COUPON_CREATOR_ADDR`, `ETH_NODE_URL`.
 
-- Mainnet deployment: `DAO_NAME`, `DAO_OWNER_ADDR`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`, `COUPON_CREATOR_ADDR`, `OFFCHAIN_ADMIN_ADDR`, `VOTING_PERIOD_SECONDS`, `GRACE_PERIOD_SECONDS`.
+- Mainnet deployment: `DAO_NAME`, `DAO_OWNER_ADDR`, `ERC20_TOKEN_NAME`, `ERC20_TOKEN_SYMBOL`, `ERC20_TOKEN_DECIMALS`, `COUPON_CREATOR_ADDR`, `OFFCHAIN_ADMIN_ADDR`, `VOTING_PERIOD_SECONDS`, `GRACE_PERIOD_SECONDS`, `ETH_NODE_URL`.
 
 ### Compile Contracts
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -21,23 +21,20 @@
 require("dotenv").config();
 require("solidity-coverage");
 
-const newHDProvider = (network) => {
-  const HDWalletProvider = require("@truffle/hdwallet-provider");
-  const infuraKey = process.env.INFURA_KEY;
-  const alchemyKey = process.env.ALCHEMY_KEY;
-  const mnemonic = process.env.TRUFFLE_MNEMONIC;
+const getNetworkProvider = () => {
+  let HDWalletProvider = require("@truffle/hdwallet-provider");
 
-  let url;
-  if (alchemyKey) {
-    url = `wss://eth-${network}.ws.alchemyapi.io/v2/${alchemyKey}`;
-  } else {
-    url = `wss://${network}.infura.io/ws/v3/${infuraKey}`;
-  }
+  if (!process.env.TRUFFLE_MNEMONIC)
+    throw Error("Missing environment variable: TRUFFLE_MNEMONIC");
+
+  if (!process.env.ETH_NODE_URL)
+    throw Error("Missing environment variable: ETH_NODE_URL");
+
   return new HDWalletProvider({
     mnemonic: {
-      phrase: mnemonic,
+      phrase: process.env.TRUFFLE_MNEMONIC,
     },
-    providerOrUrl: url,
+    providerOrUrl: process.env.ETH_NODE_URL,
   });
 };
 
@@ -49,16 +46,23 @@ module.exports = {
       network_id: "1337", // Any network (default: none)
     },
     rinkeby: {
-      provider: () => newHDProvider("rinkeby"),
+      provider: getNetworkProvider,
       network_id: 4,
       skipDryRun: true,
       networkCheckTimeout: 10000,
       deploymentPollingInterval: 10000,
     },
     mainnet: {
-      provider: () => newHDProvider("mainnet"),
+      provider: getNetworkProvider,
       network_id: 1,
       skipDryRun: true,
+    },
+    coverage: {
+      host: "localhost",
+      network_id: "*",
+      port: 8555,
+      gas: 0xfffffffffff,
+      gasPrice: 0x01,
     },
   },
 


### PR DESCRIPTION
Using `ETH_NODE_URL` instead of API keys to deploy the contracts.

This is useful because we may want to deploy using different nodes.