### PR TITLE
docs: update tutorial

### DIFF
--- a/website/docs/tutorial/dao/Configuration.md
+++ b/website/docs/tutorial/dao/Configuration.md
@@ -8,15 +8,10 @@ title: Configuration
 ## Requirements
 
 - **[Infura Ethereum API KEY](https://infura.io/product/ethereum)**: sign up for free, verify your email, create an ethereum project to get your API Key (also known as `Project Id`). We will use that to deploy the contracts to the Rinkeby network. Checkout this **[Infura Blog Post](https://blog.infura.io/getting-started-with-infura-28e41844cc89/)** for more info on that.
-- **[The Graph API Access Token](https://thegraph.com/legacy-explorer/dashboard/)**: sign up to https://thegraph.com/legacy-explorer/dashboard with your Github account, access the **[dashboard](https://thegraph.com/explorer/dashboard)**, and copy the **Access Token**. We will use that to deploy the **[Tribute DAO Subgraph](/docs/subgraph/definition)** to thegraph.com. Then click on "Add Subgraph" and type: _Tribute DAO Tutorial_, give it any subtitle, and hit _Create subgraph_.
-
-:::caution
-Be sure you are adding a subgraph in the **legacy** version of The Graph! You should see `legacy-explorer` in the URL (https://thegraph.com/legacy-explorer/dashboard).
-:::
 
 ## Configuring the project
 
-⚙️ Now that you have the tribute-contracts project prepared in your local environment, it is time to set up the DAO configs. The configs are a set of environment variables that will provide to the deployment script all the essential information to deploy the smart contracts to the correct network. In this tutorial we will be covering the deploying of the DAO using **[Rinkeby](https://rinkeby.etherscan.io/)** test network.
+⚙️ Now that you have the `tribute-contracts` project prepared in your local environment, it is time to set up the DAO configs. These configs are a set of environment variables that will provide to the deployment script all the essential information to create the smart contracts in the correct Ethereum network. In this section we will be covering the deploying of the DAO using **[Rinkeby](https://rinkeby.etherscan.io/)** test network.
 
 ### Environment Variables
 
@@ -26,10 +21,12 @@ The first step is to create a `.env` file in the root of the _tribute-contracts_
 touch .env
 ```
 
-Then set the following content to the `.env` file, and fill out each environment variable with the values as indicated in the comments below:
+Then set the following content to the `.env` file, and fill out each environment variable with the proper values as indicated in the comments below:
 
 ```bash
-# The name of the DAO.
+###### Tribute Contracts env vars ######
+
+# Set the name of your DAO.
 DAO_NAME=My First DAO
 
 # The public ethereum address that belongs to the Owner of the DAO,
@@ -37,7 +34,7 @@ DAO_NAME=My First DAO
 # Make sure you have some ETH, otherwise the deployment will fail.
 DAO_OWNER_ADDR=0x...
 
-#can set that to use the same address you have in the DAO_OWNER_ADDR
+# You can set that to use the same address you have in the DAO_OWNER_ADDR
 COUPON_CREATOR_ADDR=0x...
 
 # The name of the ERC20 token of your DAO.
@@ -45,27 +42,32 @@ ERC20_TOKEN_NAME=My First DAO Token
 
 # The symbol of your ERC20 Token that will be used to control the
 # DAO units that each member holds.
-ERC20_TOKEN_SYMBOL=FDAO
+ERC20_TOKEN_SYMBOL=TDAO
 
 # Number of decimals to display the token units in MM. We usually
 # set 0 because the DAO units are managed in WEI, and to be able
 # to see that in the MM wallet you need to remove the precision.
 ERC20_TOKEN_DECIMALS=0
 
-# The Infura Key to connect to Rinkeby network. You can follow
+# The Ethereum Node URL to connect the Ethereum network. You can follow
 # these steps to get your ProjectId/API Key from Infura:
 # https://blog.infura.io/getting-started-with-infura-28e41844cc89/
-INFURA_KEY=
+# Or can use the default one from OpenLaw team, or set your own Infura/Alchemy API keys
+#ETH_NODE_URL=wss://eth-rinkeby.ws.alchemyapi.io/v2/your-api-key
+# Replace the "your-api-key" with your infura key
+ETH_NODE_URL=wss://rinkeby.infura.io/ws/v3/your-api-key
 
 # The 12 word "secret recovery phrase" for the ethereum address
 # referenced in DAO_OWNER_ADDR above. This can be found in your wallet.
 # It will be used to create the HD wallet and sign transactions on your behalf.
 TRUFFLE_MNEMONIC=...
 
-# The Graph API Access Token that will be used to deploy the Subgraph.
-# Copy the access token from the subgraph project you have created.
-# https://thegraph.com/legacy-explorer/dashboard
-GRAPH_ACCESS_TOKEN=...
+###### Subgraph env vars ######
+
+# Set it to true if you want to deploy the subgraph to the TheGraph.com API.
+# Usually we leave it disabled because we deploy to a local Graph Node
+# created in docker/docker-compose.yml file.
+REMOTE_GRAPH_NODE=false
 ```
 
 :::caution

--- a/website/docs/tutorial/dao/Deployment.md
+++ b/website/docs/tutorial/dao/Deployment.md
@@ -9,7 +9,7 @@ title: Deployment
 
 - ⚙️ All the environment variables must be set in the _.env_ file as indicated in the previous section.
 
-- 💲 Make sure you have enough ETH.
+- 💲 Make sure you have ETH in your account (2 ETH should be more than enough).
 
 ## Deploying your DAO
 
@@ -17,16 +17,16 @@ title: Deployment
 
 The deployment process is triggered by the script `deploy:*`, where the `*` indicates which network the contracts are going to be deployed.
 
-Execute the following command from the root directory of tribute-contracts project:
+Execute the following command from the root directory of `tribute-contracts` project to deploy all the contracts to Rinkeby:
 
 ```bash
 npm run deploy:rinkeby
 ```
 
-🍺 Sit back and have some drink while the deployment script is executed. It may take from 10 to 20 minutes to deploy all the smart contracts.
+🍺 Sit back and have some drink while the deployment script is executed. It may take from 10 to 20 minutes to create all the smart contracts.
 
 :::info
-The deployment is slow mainly because we deploy all the smart contracts at once, even the ones that are not in use by the DAO. With all the contracts available in the testnet you could update the DAO to use one of the different voting adapters for instance. We certainly don't do that for Mainnet deployments, but we are constantly working to improve the developer experience, and minimize the gas costs.
+The deployment is slow mainly because we publish all the smart contracts at once, even the ones that are not in use by the DAO. We certainly don't do that for Mainnet deployments, but we are constantly working to improve the developer experience, and minimize the gas costs.
 :::
 
 At the end of the deployment process you should see the following output:

--- a/website/docs/tutorial/dao/Installation.md
+++ b/website/docs/tutorial/dao/Installation.md
@@ -8,42 +8,13 @@ sidebar_position: 2
 
 ## Requirements
 
-- **[Node.js](https://nodejs.org/en/download/)** version >= 12.12.0 or above (which can be checked by running `node -v`). You can use [nvm](https://github.com/nvm-sh/nvm) for managing multiple Node versions on a single machine installed
+- **[Node.js](https://nodejs.org/en/download/)** version >= 16.0.0 or above (which can be checked by running `node -v`). You can use [nvm](https://github.com/nvm-sh/nvm) for managing multiple Node versions on a single machine.
 - **[Git](https://git-scm.com/downloads)** version 2.15.0 or above.
 - **[Solc](https://docs.soliditylang.org/en/develop/installing-solidity.html)** version 0.8.0.
 
 ## Creating the project
 
-The easiest way to start with TributeDAO Framework is to use the command line tool to clone the Github repository and install all the project dependencies.
-
-We will use several projects to build and run the TributeDAO in your local environment, so please try to keep the following folder structure:
-
-```
-tribute-tutorial
-│
-└───tribute-contracts (branch v1.0.0)
-│   │   .env
-│   │   ...
-|   |
-│   └───subgraph (branch v1.1.0)
-│       │   .env
-│       │   ...
-│
-└───tribute-ui
-│     │   .env
-│     │   ...
-│
-└───snapshot-hub (branch erc-712)
-    │   .env
-    │   docker-compose.yml
-    │   ...
-```
-
-Create and access the tutorial folder:
-
-```bash
-mkdir tribute-tutorial && cd tribute-tutorial
-```
+The easiest way to start with TributeDAO Framework is to use the command line tool to clone the Github repository, and install all the project dependencies.
 
 Clone and access the _tribute-contracts_ Github repo:
 
@@ -51,28 +22,20 @@ Clone and access the _tribute-contracts_ Github repo:
 git clone https://github.com/openlawteam/tribute-contracts.git && cd tribute-contracts
 ```
 
+Fetch and checkout the branch `release-v1.0.3`:
+
+> git fetch origin release-v1.0.3
+
+> git checkout release-v1.0.3
+
 :::caution
-Make sure you checkout the tag [v1.0.0](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.0.0) which is the version that contains the contracts that work with [TributeUI](https://github.com/openlawteam/tribute-ui).
+Before installing the dependencies make sure you are on the branch [release-v1.0.3](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.0.3) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
 :::
 
-```bash
-git checkout tags/v1.0.0 -b branch-v1.0.0
-```
-
-Install all the project dependencies and compile the smart contracts:
+Install all the project dependencies and deploy the smart contracts:
 
 ```bash
 npm ci && npm run compile
-```
-
-The expected output from the compilation process should be:
-
-```bash
-...
-> Compiling ...
-> Artifacts written to ~/tribute-contracts/build/contracts
-> Compiled successfully using:
-   - solc: 0.8.0...
 ```
 
 ⚡️ That's is great! You have installed project dependencies, compiled all the smart contracts, and is prepared to configure the testnet deployment. Let's move to the next section!

--- a/website/docs/tutorial/dao/TributeUI.md
+++ b/website/docs/tutorial/dao/TributeUI.md
@@ -8,66 +8,42 @@ title: Tribute UI
 ## Requirements
 
 - **[Infura Ethereum API KEY](https://infura.io/product/ethereum)**, you can use the same key you created in the **[Configuration step](/docs/tutorial/dao/configuration#requirements)** of the tutorial.
-- **[The Graph API Access Token](https://thegraph.com/legacy-explorer/dashboard)**, you need to use the Access Token created in the **[Configuration step](/docs/tutorial/dao/configuration#requirements)** of the tutorial.
-- **[Snapshot Hub ERC712 Service](https://github.com/openlawteam/snapshot-hub/tree/erc-712)** to manage the offchain voting.
-- **[Alchemy API Access Token](https://www.alchemy.com/)** you can sign up to https://www.alchemy.com, create an App called _Tribute DAO Tutorial_, select _Rinkeby_ as default network, and finsh the creation process to get the integration URL.
-- **[Docker Compose](https://docs.docker.com/compose/install/)** install Docker Compose (https://docs.docker.com/compose/install/). This will be used in this tutorial to launch the snapshot-hub service.
+- **[Docker Compose](https://docs.docker.com/compose/install/)** install Docker Compose (https://docs.docker.com/compose/install/). This will be used in this tutorial to launch the local instances of snapshot-hub, graph node, and ipfs services.
 - **[MetaMask](https://metamask.io/download.html)** download and install MetaMask from https://metamask.io/download.html into your browser to access the DAO dApp.
 
-## Install the project
+## Configuring the dApp
 
-Use the command line tool to clone the Github repository and install all the project dependencies.
+In order to run the dApp we will be using `docker-compose`, which will help us to spin up all the services required by the dApp.
 
-First, make sure you are in the root of _tribute-tutorial_ folder.
-
-Then clone and access the _tribute-ui_ Github repo:
+First, set the `tribute-ui` env vars in the `tribute-contracts/.env` file, just append it to the bottom of the file:
 
 ```bash
-git clone https://github.com/openlawteam/tribute-ui.git && cd tribute-ui
-```
+######
+# Paste it after the DAO env vars declared in the previous sections, these env vars are used by the services launched with Docker Compose.
+######
 
-## Configure the environment
-
-After you cloned the Tribute UI repo, let's set up the environment variables in the root of _tribute-ui_ folder, and deploy the subgraph.
-
-```bash
-touch .env
-```
-
-Then add the following environment variables:
-
-:::tip
-You can find the **REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS** and **REACT_APP_MULTICALL_CONTRACT_ADDRESS** values in the tribute-contracts/logs/rinkeby-deploy.log.
-:::
-
-```bash
 # It can be the same value you used for the Tribute DAO deployment.
-REACT_APP_INFURA_PROJECT_ID_DEV=...
-
-# The address of the DaoRegistry smart contract deployed to the Rinkeby network.
-REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS=...
+# Replace "your-api-key" with your Infura key
+REACT_APP_INFURA_PROJECT_ID_DEV=your-api-key
 
 # The address of the Multicall smart contract deployed to the Rinkeby network.
-REACT_APP_MULTICALL_CONTRACT_ADDRESS=...
+# Copy that from the tribute-contracts/logs/[network]-deploy.log
+REACT_APP_MULTICALL_CONTRACT_ADDRESS=0x...
 
-# The url of snaphot-hub running locally in a container.
-REACT_APP_SNAPSHOT_HUB_API_URL=http://localhost:8081
+# The address of the DaoRegistry smart contract deployed to the Rinkeby network.
+# Copy that from the tribute-contracts/logs/[network]-deploy.log
+REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS=0x...
 
-# The unique name registered in Snapshot Hub under which proposals, votes, etc. will be stored.
-REACT_APP_SNAPSHOT_SPACE=tribute
-
-# The url of the subgraph running locally in a container.
-REACT_APP_GRAPH_API_URL=https://api.thegraph.com/subgraphs/name/<GITHUB_USERNAME>/tribute-dao-tutorial
-
-# Make sure it is set to development mode
-REACT_APP_ENVIRONMENT=development
+# The Ethereum Network node URL used by the Graph Node to listen to events.
+# Replace "your-api-key" with your Infura key
+ethereum=rinkeby:https://rinkeby.infura.io/v3/your-api-key
 ```
 
-:::caution
-Please do not change the REACT_APP_SNAPSHOT_SPACE, keep it as is, so it will work with the snapshot-hub service.
-:::
+Open the file:
 
-Open the Rinkeby deployment logs, scroll to the end of the file and you should see an output like this:
+> tribute-contracts/logs/rinkeby-deploy.log
+
+Scroll to the end of the file, and find an output like this:
 
 ```bash
 ************************
@@ -77,179 +53,96 @@ Multicall: 0x...
 ************************
 ```
 
-These are the address of the contracts you have deployed to Rinkeby. Just copy the address of **DaoRegistry** and **Multicall**, set them to **REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS** and **REACT_APP_MULTICALL_CONTRACT_ADDRESS** respectivelly.
+These are the addresses of the contracts you have deployed to Rinkeby network. Just copy the address of **DaoRegistry** and **Multicall**, set them to **REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS** and **REACT_APP_MULTICALL_CONTRACT_ADDRESS** respectively.
 
-Then set your Github username to _<GITHUB_USERNAME>_ in **REACT_APP_GRAPH_API_URL**, that will indicate where your subgraph needs to be created.
+## Configuring the Subgraph
 
-## Deploy the Subgraph
+Open the file:
 
-:::caution
-You need to checkout branch v1.1.0 of _tribute-contracts_ to make it work with the tribute-ui.
-:::
+> tribute-contracts/subgraph/config/subgraph-config.json
 
-Go to the `tribute-tutorial/tribute-contracts` directory and check out the the tag [v1.1.0](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.1.0) which is the version that contains the subgraph that works with [TributeUI](https://github.com/openlawteam/tribute-ui):
+You should see something like this:
 
 ```bash
-cd ../tribute-contracts
-```
-
-Then checkout the correct branch _v1.1.0_, install the project dependencies:
-
-```bash
-git checkout tags/v1.1.0 -b branch-v1.1.0 && npm ci
-```
-
-Access the `subgraph` folder in `tribute-contracts`:
-
-```bash
-cd subgraph
-```
-
-Then open the config file: _subgraph/config/subgraph-config.json_, remove all the entries and add your subgraph config:
-
-```json
+### tribute-contracts/subgraph/config/subgraph-config.json
 [
   {
     "network": "rinkeby",
-    "daoFactoryAddress": "0x...",
-    "daoFactoryStartBlock": ...,
-    "GITHUB_USERNAME": "<YOUR_GITHUB_USERNAME>",
-    "SUBGRAPH_NAME": "tribute-dao-tutorial"
+    "daoFactoryAddress": "0x...", # Copy the DaoFactory contracts address from the deployment logs.
+    "daoFactoryStartBlock": blockNumber, # Copy the DaoFactory blockNumber from the deployment logs.
+    "GITHUB_USERNAME": "openlawteam", # do not change it
+    "SUBGRAPH_NAME": "tribute"  # do not change it
   }
 ]
 ```
 
-In the rinkeby deployment logs at _tribute-contracts/logs/rinkeby-deploy.log_ search by **DaoFactory** and copy the **contract address** and **block number**, set the values to **daoFactoryAddress** and **daoFactoryStartBlock** respectively.
+In the Rinkeby deployment logs at _tribute-contracts/logs/rinkeby-deploy.log_ search by **DaoFactory** and copy the **contract address** and **block number**, set the values to **daoFactoryAddress** and **daoFactoryStartBlock** respectively.
 
-Finally, set your Github username to **GITHUB_USERNAME**, it must be the same Github account that you used to connect to thegraph.com.
+## Starting the services
 
-:::caution
-The **SUBGRAPH_NAME** should be lowercase and any spaces should be hyphenated, it needs to match the subgraph slug you picked when you created the subgraph in thegraph.com. If you're not sure, go to the [Subgraph Legacy Explorer](https://thegraph.com/legacy-explorer/dashboard), navigate to your subgraph, and look for "subgraph slug." or once you click on your subgraph, copy the slug from the browser URL. You should see something like: https://thegraph.com/legacy-explorer/subgraph/[your-github-user]/[slug].
-:::
-
-From the `tribute-tutorial/tribute-contracts/subgraph` folder, install the dependencies using Node v14.x:
-
-```bash
-npm ci
-```
-
-Create the **.env** file under the _subgraph_ folder:
-
-```bash
-touch .env
-```
-
-Add the subgraph API access token:
-
-```bash
-# The Graph API Access Token that will be used to deploy the Subgraph.
-# Copy the Access Token from: https://thegraph.com/legacy-explorer/dashboard
-GRAPH_ACCESS_TOKEN=
-```
-
-Start the Subgraph deployment:
-
-```bash
-npx ts-node subgraph-deployer.ts
-```
-
-At the end of the process you should see an output like this:
-
-```bash
-✔ Upload subgraph to IPFS
-
-Build completed: ...
-
-Deployed to https://thegraph.com/explorer/subgraph/<your-github-username>/tribute-dao-tutorial
-
-Subgraph endpoints:
-Queries (HTTP):     https://api.thegraph.com/subgraphs/name/<your-github-username>/tribute-dao-tutorial
-Subscriptions (WS): wss://api.thegraph.com/subgraphs/name/<your-github-username>/tribute-dao-tutorial
-
-👏 ### Done.
-🎉 ### 1 Deployment(s) Successful!
-```
-
-## Launch the Snapshot Hub ERC712 service
-
-Use the command line tool to clone the Github repository and launch the docker container.
-This can be done in any directory, but to keep it consistent let's checkout the project from the _tribute-tutorial_ folder.
-
-Clone and access the _snapshot-hub_ Github repo:
-
-```bash
-git clone https://github.com/openlawteam/snapshot-hub.git && cd snapshot-hub
-```
-
-Checkout the correct branch and create the _.env.local_ file:
-
-```bash
-git fetch origin erc-712 && git checkout erc-712 && touch .env.local
-```
-
-Copy the following content to the new _.env.local_ file:
-
-```bash
-# The port number to start the service.
-PORT=8080
-# The type of the ethereum network.
-NETWORK=testnet
-# The flag to indicate if the snapshot-hub should use IPFS to store data.
-USE_IPFS=false
-# The 64 digits private key of the hd wallet that will be used to sign messages.
-# Feel free to generate a new random 64 digit hexadecimal number for this.
-RELAYER_PK=0x..
-# The allow list of domain that will be using the service.
-ALLOWED_DOMAINS=http://localhost:3000
-# The Alchemy API URL and access token to talk to Rinkeby ethereum network.
-ALCHEMY_API_URL=https://eth-rinkeby.alchemyapi.io/v2/<ACCESS_TOKEN>
-```
-
-Add your Alchemy API access token to `ALCHEMY_API_URL` in `.env.local`
-
-Next add a 64 digit hexadecimal number to `RELAYER_PK` in `.env.local`.
-A hexadecimal creator can be found here: https://numbergenerator.org/random-64-digit-hex-codes-generator
-
-From the `snapshot-hub` root folder install the dependencies:
-
-```bash
-npm ci
-```
-
-Finally, start the snapshot-hub erc712 service:
+Using docker-compose let's start all the services in the `tribute-contracts/docker ` folder:
 
 ```bash
 docker-compose up
 ```
 
-You should see this in the terminal:
+This command will launch the several services that are integrated with Tribute DAO, and are essential to interact with the contracts in the Ethereum Network.
 
-![image](https://user-images.githubusercontent.com/6320310/134381117-80075a7d-db3a-46b8-a1d8-55f187d89c0e.png)
+Wait for the following output:
 
-## Running the Tribute UI dApp
-
-Alright, we are almost done. Now we will set up the Tribute UI dApp, so you can interact with your DAO that was deployed to Rinkeby.
-
-You already deployed the Subgraph, and prepared the Snapshot Hub service, now let's start use the command line to start the dApp.
-
-From the `tribute-ui` root folder, execute:
-
-```bash
-npm ci
+```
+  trib-ui              | Compiled successfully!
+  trib-ui              |
+  trib-ui              | You can now view tribute-ui in the browser.
+  trib-ui              |
+  trib-ui              |   Local:            http://localhost:3000
+  trib-ui              |   On Your Network:  http://a.b.c.d:3000
+  trib-ui              |
+  trib-ui              | Note that the development build is not optimized.
+  trib-ui              | To create a production build, use npm run build.
+  trib-ui              |
+  trib-graph-node      | Sep 24 14:02:47.585 INFO Syncing 1 blocks from Ethereum., code: BlockIngestionStatus, blocks_needed: 1, blocks_behind: 1, latest_block_head: 9349060, current_block_head: 9349059, provider: rinkeby-rpc-0, component: BlockIngestor
+  ...
 ```
 
-Start the dApp:
+## Deploying the Subgraph
+
+The dApp uses the subgraph to index and query the chain data, we already have it configured, but we still need to deploy it to our local graph node that we started with docker-compose.
+
+In another terminal window access the subgraph folder `tribute-contracts/subgraph`:
 
 ```bash
-npm start
+cd subgraph
 ```
 
-You should see this in your terminal:
-![image](https://user-images.githubusercontent.com/6320310/134383377-77226885-20b9-4042-bc33-9364cc878852.png)
+Install the dependencies using node v16+:
+
+```bash
+npm install
+```
+
+Deploy the subgraph:
+
+```bash
+npx ts-node subgraph-deployer.ts
+```
+
+Wait for the following output:
+
+```bash
+Deployed to http://localhost:8000/subgraphs/name/openlawteam/tribute/graphql
+
+Subgraph endpoints:
+Queries (HTTP):     http://localhost:8000/subgraphs/name/openlawteam/tribute
+Subscriptions (WS): http://localhost:8001/subgraphs/name/openlawteam/tribute
+
+👏 ### Done.
+🎉 ### 1 Deployment(s) Successful!
+```
 
 ## Interacting with the DAO
 
-Open your browser and access http://localhost:3001.
+Open your browser and access [http://localhost:3000](http://localhost:3000).
 
 You should see the Tribute UI onboarding page:
 
@@ -267,13 +160,9 @@ Access the _Governance_ page and hit _new proposal_ to create a proposal for vot
 
 ![Governance](/img/tutorial/dao-tutorial/governance.png)
 
-👏 Well Done!!!
+👏 Yeah, it was a lengthy tutorial, Well Done!!!
 
-🎉 You have launched your DAO using Tribute DAO Framework and now you can interact with it using the TributeUI dApp!
-
-:::info
-It was a lengthy tutorial, but we are constantly working to improve the deployment and configuration process.
-:::
+🎉 You have launched your DAO using Tribute DAO framework, and now you can interact with it using the Tribute UI dApp!
 
 ## Problems?
 


### PR DESCRIPTION
Updated the tutorial to use the contracts from branch `release-v1.0.3`, and simplified the steps to launch the DAO using docker-compose with local `ipfs`, `snapshot-hub`, and `graph-node` instances.