### PR TITLE
fix: subgraph for latest smart contracts; clean up fixes in deployment files

### DIFF
--- a/migrations/configs/ganache.config.ts
+++ b/migrations/configs/ganache.config.ts
@@ -1,12 +1,13 @@
-import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import { contracts as defaultContracts } from "./contracts.config";
-import { getNetworkDetails } from "../../utils/deployment-util";
+import {
+  contracts as defaultContracts,
+  ContractConfig,
+} from "./contracts.config";
 
 const disabled: Array<string> = [
   // Utility & Test Contracts disabled by default
-  // "OLToken",
-  // "TestToken1",
-  // "TestToken2",
+  "OLToken",
+  "TestToken1",
+  "TestToken2",
   "TestFairShareCalc",
   "PixelNFT",
   "ProxToken",
@@ -14,22 +15,9 @@ const disabled: Array<string> = [
   "MockDao",
 ];
 
-export const contracts = defaultContracts
-  .map((c) => {
-    if (disabled.find((e) => e === c.name)) {
-      return { ...c, enabled: false };
-    }
-    return c;
-  })
-  .map((c) => {
-    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
-      const chainDetails = getNetworkDetails("ganache");
-      return {
-        ...c,
-        deploymentArgs: {
-          chainId: chainDetails?.chainId,
-        },
-      };
-    }
-    return c;
-  });
+export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});

--- a/migrations/configs/ganache.config.ts
+++ b/migrations/configs/ganache.config.ts
@@ -6,8 +6,6 @@ import {
 const disabled: Array<string> = [
   // Utility & Test Contracts disabled by default
   "OLToken",
-  "TestToken1",
-  "TestToken2",
   "TestFairShareCalc",
   "PixelNFT",
   "ProxToken",

--- a/migrations/configs/ganache.config.ts
+++ b/migrations/configs/ganache.config.ts
@@ -1,13 +1,12 @@
-import {
-  contracts as defaultContracts,
-  ContractConfig,
-} from "./contracts.config";
+import { adaptersIdsMap } from "../../utils/dao-ids-util";
+import { contracts as defaultContracts } from "./contracts.config";
+import { getNetworkDetails } from "../../utils/deployment-util";
 
 const disabled: Array<string> = [
   // Utility & Test Contracts disabled by default
-  "OLToken",
-  "TestToken1",
-  "TestToken2",
+  // "OLToken",
+  // "TestToken1",
+  // "TestToken2",
   "TestFairShareCalc",
   "PixelNFT",
   "ProxToken",
@@ -15,9 +14,22 @@ const disabled: Array<string> = [
   "MockDao",
 ];
 
-export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
-  if (disabled.find((e) => e === c.name)) {
-    return { ...c, enabled: false };
-  }
-  return c;
-});
+export const contracts = defaultContracts
+  .map((c) => {
+    if (disabled.find((e) => e === c.name)) {
+      return { ...c, enabled: false };
+    }
+    return c;
+  })
+  .map((c) => {
+    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
+      const chainDetails = getNetworkDetails("ganache");
+      return {
+        ...c,
+        deploymentArgs: {
+          chainId: chainDetails?.chainId,
+        },
+      };
+    }
+    return c;
+  });

--- a/migrations/configs/goerli.config.ts
+++ b/migrations/configs/goerli.config.ts
@@ -1,6 +1,7 @@
-import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import { contracts as defaultContracts } from "./contracts.config";
-import { getNetworkDetails } from "../../utils/deployment-util";
+import {
+  contracts as defaultContracts,
+  ContractConfig,
+} from "./contracts.config";
 
 const disabled: Array<string> = [
   // Utility & Test Contracts disabled by default
@@ -14,22 +15,9 @@ const disabled: Array<string> = [
   "MockDao",
 ];
 
-export const contracts = defaultContracts
-  .map((c) => {
-    if (disabled.find((e) => e === c.name)) {
-      return { ...c, enabled: false };
-    }
-    return c;
-  })
-  .map((c) => {
-    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
-      const chainDetails = getNetworkDetails("goerli");
-      return {
-        ...c,
-        deploymentArgs: {
-          chainId: chainDetails?.chainId,
-        },
-      };
-    }
-    return c;
-  });
+export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});

--- a/migrations/configs/goerli.config.ts
+++ b/migrations/configs/goerli.config.ts
@@ -22,7 +22,7 @@ export const contracts = defaultContracts
     return c;
   })
   .map((c) => {
-    if (adaptersIdsMap.COUPON_MANAGER_ADAPTER === c.id) {
+    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
       const chainDetails = getNetworkDetails("goerli");
       return {
         ...c,

--- a/migrations/configs/harmony.config.ts
+++ b/migrations/configs/harmony.config.ts
@@ -1,6 +1,7 @@
-import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import { contracts as defaultContracts } from "./contracts.config";
-import { getNetworkDetails } from "../../utils/deployment-util";
+import {
+  contracts as defaultContracts,
+  ContractConfig,
+} from "./contracts.config";
 
 const disabled: Array<String> = [
   // Utility & Test Contracts disabled by default
@@ -20,22 +21,9 @@ const disabled: Array<String> = [
   "DistributeContract",
 ];
 
-export const contracts = defaultContracts
-  .map((c) => {
-    if (disabled.find((e) => e === c.name)) {
-      return { ...c, enabled: false };
-    }
-    return c;
-  })
-  .map((c) => {
-    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
-      const chainDetails = getNetworkDetails("harmony");
-      return {
-        ...c,
-        deploymentArgs: {
-          chainId: chainDetails?.chainId,
-        },
-      };
-    }
-    return c;
-  });
+export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});

--- a/migrations/configs/harmony.config.ts
+++ b/migrations/configs/harmony.config.ts
@@ -1,7 +1,5 @@
 import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import {
-  contracts as defaultContracts,
-} from "./contracts.config";
+import { contracts as defaultContracts } from "./contracts.config";
 import { getNetworkDetails } from "../../utils/deployment-util";
 
 const disabled: Array<String> = [
@@ -30,7 +28,7 @@ export const contracts = defaultContracts
     return c;
   })
   .map((c) => {
-    if (adaptersIdsMap.COUPON_MANAGER_ADAPTER === c.id) {
+    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
       const chainDetails = getNetworkDetails("harmony");
       return {
         ...c,

--- a/migrations/configs/harmonytest.config.ts
+++ b/migrations/configs/harmonytest.config.ts
@@ -22,7 +22,7 @@ export const contracts = defaultContracts
     return c;
   })
   .map((c) => {
-    if (adaptersIdsMap.COUPON_MANAGER_ADAPTER === c.id) {
+    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
       const chainDetails = getNetworkDetails("harmonytest");
       return {
         ...c,

--- a/migrations/configs/harmonytest.config.ts
+++ b/migrations/configs/harmonytest.config.ts
@@ -1,6 +1,7 @@
-import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import { contracts as defaultContracts } from "./contracts.config";
-import { getNetworkDetails } from "../../utils/deployment-util";
+import {
+  contracts as defaultContracts,
+  ContractConfig,
+} from "./contracts.config";
 
 const disabled: Array<string> = [
   // Utility & Test Contracts disabled by default
@@ -14,22 +15,9 @@ const disabled: Array<string> = [
   "MockDao",
 ];
 
-export const contracts = defaultContracts
-  .map((c) => {
-    if (disabled.find((e) => e === c.name)) {
-      return { ...c, enabled: false };
-    }
-    return c;
-  })
-  .map((c) => {
-    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
-      const chainDetails = getNetworkDetails("harmonytest");
-      return {
-        ...c,
-        deploymentArgs: {
-          chainId: chainDetails?.chainId,
-        },
-      };
-    }
-    return c;
-  });
+export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});

--- a/migrations/configs/mainnet.config.ts
+++ b/migrations/configs/mainnet.config.ts
@@ -1,6 +1,7 @@
-import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import { contracts as defaultContracts } from "./contracts.config";
-import { getNetworkDetails } from "../../utils/deployment-util";
+import {
+  contracts as defaultContracts,
+  ContractConfig,
+} from "./contracts.config";
 
 const disabled: Array<String> = [
   // Utility & Test Contracts disabled by default
@@ -20,22 +21,9 @@ const disabled: Array<String> = [
   "DistributeContract",
 ];
 
-export const contracts = defaultContracts
-  .map((c) => {
-    if (disabled.find((e) => e === c.name)) {
-      return { ...c, enabled: false };
-    }
-    return c;
-  })
-  .map((c) => {
-    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
-      const chainDetails = getNetworkDetails("mainnet");
-      return {
-        ...c,
-        deploymentArgs: {
-          chainId: chainDetails?.chainId,
-        },
-      };
-    }
-    return c;
-  });
+export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});

--- a/migrations/configs/mainnet.config.ts
+++ b/migrations/configs/mainnet.config.ts
@@ -1,7 +1,5 @@
 import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import {
-  contracts as defaultContracts,
-} from "./contracts.config";
+import { contracts as defaultContracts } from "./contracts.config";
 import { getNetworkDetails } from "../../utils/deployment-util";
 
 const disabled: Array<String> = [
@@ -30,7 +28,7 @@ export const contracts = defaultContracts
     return c;
   })
   .map((c) => {
-    if (adaptersIdsMap.COUPON_MANAGER_ADAPTER === c.id) {
+    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
       const chainDetails = getNetworkDetails("mainnet");
       return {
         ...c,

--- a/migrations/configs/rinkeby.config.ts
+++ b/migrations/configs/rinkeby.config.ts
@@ -1,6 +1,7 @@
-import { adaptersIdsMap } from "../../utils/dao-ids-util";
-import { contracts as defaultContracts } from "./contracts.config";
-import { getNetworkDetails } from "../../utils/deployment-util";
+import {
+  contracts as defaultContracts,
+  ContractConfig,
+} from "./contracts.config";
 
 const disabled: Array<string> = [
   // Utility & Test Contracts disabled by default
@@ -14,22 +15,9 @@ const disabled: Array<string> = [
   "MockDao",
 ];
 
-export const contracts = defaultContracts
-  .map((c) => {
-    if (disabled.find((e) => e === c.name)) {
-      return { ...c, enabled: false };
-    }
-    return c;
-  })
-  .map((c) => {
-    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
-      const chainDetails = getNetworkDetails("rinkeby");
-      return {
-        ...c,
-        deploymentArgs: {
-          chainId: chainDetails?.chainId,
-        },
-      };
-    }
-    return c;
-  });
+export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
+  if (disabled.find((e) => e === c.name)) {
+    return { ...c, enabled: false };
+  }
+  return c;
+});

--- a/migrations/configs/rinkeby.config.ts
+++ b/migrations/configs/rinkeby.config.ts
@@ -22,7 +22,7 @@ export const contracts = defaultContracts
     return c;
   })
   .map((c) => {
-    if (adaptersIdsMap.COUPON_MANAGER_ADAPTER === c.id) {
+    if (adaptersIdsMap.COUPON_ONBOARDING_ADAPTER === c.id) {
       const chainDetails = getNetworkDetails("rinkeby");
       return {
         ...c,

--- a/subgraph/mappings/core/dao-constants.ts
+++ b/subgraph/mappings/core/dao-constants.ts
@@ -13,6 +13,9 @@ export let TOTAL: Address = Address.fromString(
 export let MEMBER_COUNT: Address = Address.fromString(
   "0x00000000000000000000000000000000decafbad"
 );
+export let ESCROW: Address = Address.fromString(
+  "0x0000000000000000000000000000000000004bec"
+);
 
 // adapter/extension names hashed (lowercase)
 

--- a/subgraph/mappings/extensions/bank-extension-mapping.ts
+++ b/subgraph/mappings/extensions/bank-extension-mapping.ts
@@ -14,11 +14,12 @@ import {
   Extension,
 } from "../../generated/schema";
 import {
-  GUILD,
-  UNITS,
-  TOTAL,
-  MEMBER_COUNT,
   ERC20_EXTENSION_ID,
+  ESCROW,
+  GUILD,
+  MEMBER_COUNT,
+  TOTAL,
+  UNITS,
 } from "../core/dao-constants";
 
 function internalTransfer(
@@ -38,9 +39,11 @@ function internalTransfer(
     TOTAL.toHex() != memberAddress.toHex() &&
     GUILD.toHex() != memberAddress.toHex() &&
     MEMBER_COUNT.toHex() != memberAddress.toHex() &&
+    ESCROW.toHex() != memberAddress.toHex() &&
     TOTAL.toHex() != tokenAddress.toHex() &&
     GUILD.toHex() != tokenAddress.toHex() &&
-    MEMBER_COUNT.toHex() != tokenAddress.toHex()
+    MEMBER_COUNT.toHex() != tokenAddress.toHex() &&
+    ESCROW.toHex() != tokenAddress.toHex()
   ) {
     // check if the DAO has an ERC20 extension and assign members balance
     internalERC20Balance(daoAddress, memberAddress);

--- a/subgraph/mappings/extensions/bank-extension-mapping.ts
+++ b/subgraph/mappings/extensions/bank-extension-mapping.ts
@@ -85,12 +85,20 @@ function internalTransfer(
     member.save();
   }
 
-  // get totalUnits in the dao
+  // get total units minted/authorized for the DAO
   let balanceOfTotalUnits = bankRegistry.balanceOf(TOTAL, UNITS);
+  // get balance of units owned by the guild bank
+  let balanceOfGuildUnits = bankRegistry.balanceOf(GUILD, UNITS);
+  // get total units issued and outstanding in the DAO (not owned by guild bank)
+  let balanceOfTotalUnitsIssued = balanceOfTotalUnits.minus(
+    balanceOfGuildUnits
+  );
+
   let dao = TributeDao.load(daoAddress.toHexString());
 
   if (dao != null) {
     dao.totalUnits = balanceOfTotalUnits.toString();
+    dao.totalUnitsIssued = balanceOfTotalUnitsIssued.toString();
 
     dao.save();
   }

--- a/subgraph/mappings/extensions/bank-extension-mapping.ts
+++ b/subgraph/mappings/extensions/bank-extension-mapping.ts
@@ -85,7 +85,7 @@ function internalTransfer(
     member.save();
   }
 
-  // get total units minted/authorized for the DAO
+  // get total units minted for the DAO
   let balanceOfTotalUnits = bankRegistry.balanceOf(TOTAL, UNITS);
   // get balance of units owned by the guild bank
   let balanceOfGuildUnits = bankRegistry.balanceOf(GUILD, UNITS);

--- a/subgraph/mappings/helpers/proposal-details.ts
+++ b/subgraph/mappings/helpers/proposal-details.ts
@@ -168,10 +168,10 @@ function managing(
   let proposal = Proposal.load(daoProposalId);
 
   if (proposal) {
-    proposal.adapterId = data.value0;
-    proposal.adapterAddress = data.value1;
+    proposal.adapterOrExtensionId = data.value0;
+    proposal.adapterOrExtensionAddr = data.value1;
 
-    proposal.adapterAddress = adapterAdddress;
+    proposal.adapterOrExtensionAddr = adapterAdddress;
 
     // @todo
     // let keys: Bytes[] = [];

--- a/subgraph/mappings/helpers/vote-results.ts
+++ b/subgraph/mappings/helpers/vote-results.ts
@@ -86,9 +86,9 @@ export function loadProposalAndSaveVoteResults(
           proposal.gracePeriodStartingTime = voteResults.value6;
           proposal.isChallenged = voteResults.value7;
           proposal.stepRequested = voteResults.value8;
+          proposal.forceFailed = voteResults.value9;
           // @todo its a mapping, not generated in schema
           // proposal.fallbackVotes = voteResults.value10;
-          proposal.forceFailed = voteResults.value9;
           proposal.fallbackVotesCount = voteResults.value10;
 
           proposal.votingState = voteState.toString();

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -22,7 +22,7 @@ type TributeDao @entity {
   "The DAO creator address"
   creator: Bytes
   createdAt: String
-  "Total units minted/authorized for the DAO"
+  "Total units minted for the DAO"
   totalUnits: String
   "Total units issued and outstanding"
   totalUnitsIssued: String

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -119,6 +119,8 @@ type Proposal @entity {
 
   # MANAGING; proposal details
   "Additional details for the managing proposal"
+  adapterOrExtensionId: Bytes
+  adapterOrExtensionAddr: Bytes
   keys: [Bytes!]
   values: [BigInt!]
 
@@ -134,8 +136,8 @@ type Proposal @entity {
   gracePeriodStartingTime: BigInt
   isChallenged: Boolean
   stepRequested: BigInt
-  # fallbackVotes: BigInt
   forceFailed: Boolean
+  # fallbackVotes: BigInt
   fallbackVotesCount: BigInt
 
   # ONCHAIN VOTES: additional info

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -22,7 +22,10 @@ type TributeDao @entity {
   "The DAO creator address"
   creator: Bytes
   createdAt: String
+  "Total units minted/authorized for the DAO"
   totalUnits: String
+  "Total units issued and outstanding"
+  totalUnitsIssued: String
   "The bank of the DAO"
   bank: Bank! @derivedFrom(field: "tributeDao")
   "List of registered adapters"

--- a/utils/deployment-util.js
+++ b/utils/deployment-util.js
@@ -469,11 +469,11 @@ const configureDao = async ({
           .then(() =>
             contractConfigs.daoConfigs.reduce(
               (q, configEntry) =>
-                q.then(() => {
+                q.then(async () => {
                   const configValues = configEntry.map((configName) =>
                     readConfigValue(configName, contractConfigs.name)
                   );
-                  return adapter
+                  return await adapter
                     .configureDao(...configValues, {
                       from: options.owner,
                     })


### PR DESCRIPTION
## Proposed Changes

- patch fix subgraph mappings and schema to work with latest smart contracts on `master` branch
- add `totalUnitsIssued` to schema and bank extension mapping to handle distinction between total units minted for the DAO and total units issued and outstanding (not owned by guild bank)
- exclude `ESCROW` address from member list in subgraph
- fix setting dao configs (with `async` `await`)
- remove deprecated `deploymentArgs` settings in network config files