### PR TITLE
chore: recover from failed deployment

### DIFF
--- a/deploy-config.js
+++ b/deploy-config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  deployConfigs: {
+    /**
+     * Directory where the deployment script stores the metadata
+     * about the created contracts for failure recover.
+     */
+    checkpointDir: "./build",
+    /**
+     * Directory where the deployment logs will be stored in plain text format.
+     */
+    deployLogsDir: "./logs",
+    /**
+     * Directory where the addresses and names of all deployed contracts will
+     * be stored in json format.
+     */
+    deployedContractsDir: "./build",
+  },
+};

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,6 @@
 const log = console.log;
 const fs = require("fs");
+const path = require("path");
 
 const {
   toBN,
@@ -13,7 +14,7 @@ const {
 } = require("../utils/contract-util");
 
 const { deployDao, getNetworkDetails } = require("../utils/deployment-util");
-
+const { deployConfigs } = require("../deploy-config");
 require("dotenv").config();
 
 module.exports = async (deployer, network, accounts) => {
@@ -60,10 +61,7 @@ module.exports = async (deployer, network, accounts) => {
         log(`${c.configs.name}: ${c.address}`);
         addresses[c.configs.name] = c.address;
       });
-    const filename = `build/${network}-deployment-${new Date().toISOString()}.json`;
-    fs.writeFileSync(filename, JSON.stringify(addresses), "utf8");
-    log("************************************************");
-    log(`\nDeployed contracts: ${filename}`);
+    saveDeployedContracts(network, addresses);
   } else {
     log("************************************************");
     log("no migration for network " + network);
@@ -454,4 +452,12 @@ const checkEnvVariable = (...names) => {
     envVariables[name] = process.env[name];
   });
   return envVariables;
+};
+const saveDeployedContracts = (network, addresses) => {
+  const now = new Date().toISOString();
+  const dir = path.resolve(deployConfigs.deployedContractsDir);
+  const file = `${dir}/contracts-${network}-${now}.json`;
+  fs.writeFileSync(`${file}`, JSON.stringify(addresses), "utf8");
+  log("************************************************");
+  log(`\nDeployed contracts: ${file}\n`);
 };

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "deploy:harmony": "truffle deploy --network harmony --reset 2>&1 | tee logs/harmony-deploy_`date '+%F_%T'`.log",
     "deploy:mainnet": "truffle deploy --network mainnet --reset 2>&1 | tee logs/mainnet-deploy_`date '+%F_%T'`.log",
     "ganache": "ganache-cli --deterministic -p 7545 --networkId 1337",
+    "ganache:fork": "ganache-cli --deterministic -f ",
     "lint": "prettier --list-different 'contracts/**/*.sol' '**/*.js' '**/*.md'",
     "lint:fix": "prettier --write 'contracts/**/*.sol' '**/*.js' '**/*.md'",
     "migrate": "truffle migrate --network",

--- a/utils/checkpoint-utils.ts
+++ b/utils/checkpoint-utils.ts
@@ -1,0 +1,64 @@
+const fs = require("fs");
+const path = require("path");
+const {
+  ContractType,
+  ContractConfig,
+} = require("../migrations/configs/contracts.config");
+const { deployConfigs } = require("../deploy-config");
+const checkpointDir = path.resolve(deployConfigs.checkpointDir);
+const checkpointPath = path.resolve(`${checkpointDir}/checkpoints.json`);
+
+const log = (msg: string) => {
+  if (process.env.DEBUG === "true") console.log(msg);
+};
+
+const save = (checkpoints: JSON) => {
+  fs.writeFileSync(checkpointPath, JSON.stringify(checkpoints), "utf-8");
+};
+
+const load = () => {
+  try {
+    return JSON.parse(fs.readFileSync(checkpointPath, "utf-8"));
+  } catch (e) {
+    return {};
+  }
+};
+
+export const checkpoint = (contract: any) => {
+  try {
+    if (
+      contract.configs.type === ContractType.Core ||
+      contract.configs.type === ContractType.Factory ||
+      contract.configs.type === ContractType.Extension
+    ) {
+      return contract;
+    }
+
+    if (!fs.existsSync(checkpointDir)) {
+      fs.mkdirSync(checkpointDir);
+    }
+    const checkpoints = load();
+    checkpoints[contract.configs.name] = {
+      address: contract.address,
+      ts: new Date().getTime(),
+    };
+    save(checkpoints);
+    log(`Checkpoint: ${contract.configs.name}:${contract.address}`);
+  } catch (e) {
+    console.error(e);
+  }
+  return contract;
+};
+
+export const restore = async (
+  contractInterface: any,
+  contractConfigs: typeof ContractConfig
+) => {
+  const checkpoints = load();
+  const checkpoint = checkpoints[contractConfigs.name];
+  if (checkpoint) {
+    log(`Restored: ${contractConfigs.name}:${checkpoint.address}`);
+    return await contractInterface.at(checkpoint.address);
+  }
+  return null;
+};


### PR DESCRIPTION
## Proposed Changes

- New utility script to save/restore deployed contracts from the file system
- Updated the truffle-util to add a checkpoint for every adapter successfully deployed. If the deployment fails for any reason in the next run it will first attempt to restore the contract from the checkpoints.json, if not present it will deploy a new contract. Core, Factory and Extensions are not stored in the checkpoints.json because we always want to deploy them.
