### PR TITLE
chore: read chainId from block

### DIFF
--- a/contracts/adapters/CouponOnboarding.sol
+++ b/contracts/adapters/CouponOnboarding.sol
@@ -54,8 +54,6 @@ contract CouponOnboardingContract is AdapterGuard, Signatures {
     bytes32 constant ERC20InternalTokenAddr =
         keccak256("coupon-onboarding.erc20.internal.token.address");
 
-    uint256 private _chainId;
-
     mapping(address => mapping(uint256 => uint256)) private _flags;
 
     event CouponRedeemed(
@@ -71,15 +69,13 @@ contract CouponOnboardingContract is AdapterGuard, Signatures {
      * @param erc20 the address of the internal ERC20 token to issue shares
      * @param tokenAddrToMint the address of the token to mint the coupon
      * @param maxAmount max amount of coupons to mint
-     * @param chainId the chain id in which it will be minted, and is used as part of the hash
      */
     function configureDao(
         DaoRegistry dao,
         address signerAddress,
         address erc20,
         address tokenAddrToMint,
-        uint88 maxAmount,
-        uint256 chainId
+        uint88 maxAmount
     ) external onlyAdapter(dao) {
         dao.setAddressConfiguration(SignerAddressConfig, signerAddress);
         dao.setAddressConfiguration(ERC20InternalTokenAddr, erc20);
@@ -100,7 +96,6 @@ contract CouponOnboardingContract is AdapterGuard, Signatures {
                 maxAmount - currentBalance
             );
         }
-        _chainId = chainId;
     }
 
     /**
@@ -122,7 +117,7 @@ contract CouponOnboardingContract is AdapterGuard, Signatures {
             )
         );
 
-        return hashMessage(dao, _chainId, address(this), message);
+        return hashMessage(dao, block.chainid, address(this), message);
     }
 
     /**

--- a/contracts/adapters/voting/SnapshotProposalContract.sol
+++ b/contracts/adapters/voting/SnapshotProposalContract.sol
@@ -83,8 +83,6 @@ contract SnapshotProposalContract {
         bytes32 proposalId;
     }
 
-    uint256 public chainId;
-
     function DOMAIN_SEPARATOR(DaoRegistry dao, address actionId)
         public
         view
@@ -96,15 +94,11 @@ contract SnapshotProposalContract {
                     EIP712_DOMAIN_TYPEHASH,
                     keccak256("Snapshot Message"), // string name
                     keccak256("4"), // string version
-                    chainId, // uint256 chainId
+                    block.chainid, // uint256 chainId
                     address(dao), // address verifyingContract,
                     actionId
                 )
             );
-    }
-
-    constructor(uint256 _chainId) {
-        chainId = _chainId;
     }
 
     function hashMessage(

--- a/migrations/configs/contracts.config.ts
+++ b/migrations/configs/contracts.config.ts
@@ -819,7 +819,6 @@ export const contracts: Array<ContractConfig> = [
     enabled: true,
     version: "1.0.0",
     type: ContractType.Adapter,
-    deploymentArgs: ["chainId"],
     acls: {
       dao: [daoAccessFlagsMap.NEW_MEMBER],
       extensions: {
@@ -837,7 +836,6 @@ export const contracts: Array<ContractConfig> = [
         extensionsIdsMap.ERC20_EXT, //loads the address from the ext
         "unitTokenToMint",
         "maxAmount",
-        "chainId",
       ],
     ],
   },

--- a/utils/deployment-util.js
+++ b/utils/deployment-util.js
@@ -614,8 +614,7 @@ const configureOffchainVoting = async ({
   );
 
   const snapshotProposalContract = await deployFunction(
-    SnapshotProposalContract,
-    [chainId]
+    SnapshotProposalContract
   );
 
   const offchainVotingHashContract = await deployFunction(

--- a/website/docs/contracts/adapters/onboarding/CouponOnboarding.md
+++ b/website/docs/contracts/adapters/onboarding/CouponOnboarding.md
@@ -49,10 +49,6 @@ The coupon structure contains the data fields necessary to redeem and add a new 
 
 ## Storage
 
-### \_chainId
-
-The chain id in which it has been deployed, which is used to hash the coupon message.
-
 ### \_flags
 
 Tracks all the coupons that were redeemed per DAO.
@@ -67,30 +63,22 @@ The address of the token that will be created and issued to the address in the r
 
 ## Functions
 
-### receive
-
-```solidity
-/**
- * @notice default fallback function to prevent from sending ether to the contract
- */
-receive() external payable {
-  revert("fallback revert");
-}
-
-```
-
-### configure
+### configureDao
 
 ```solidity
    /**
-    * @notice Configures the Adapter with the coupon signer address and token to mint.
-    * @param signerAddress is the DAO instance to be configured
-    * @param tokenAddrToMint is the coupon to hash
-    */
+     * @notice Configures the Adapter with the coupon signer address and token to mint.
+     * @param signerAddress the address of the coupon signer
+     * @param erc20 the address of the internal ERC20 token to issue shares
+     * @param tokenAddrToMint the address of the token to mint the coupon
+     * @param maxAmount max amount of coupons to mint
+     */
     function configureDao(
         DaoRegistry dao,
         address signerAddress,
-        address tokenAddrToMint
+        address erc20,
+        address tokenAddrToMint,
+        uint88 maxAmount
     ) external onlyAdapter(dao)
 ```
 


### PR DESCRIPTION
## Proposed Changes

- CouponOnboarding + SnapshotProposalContract were changed to read the `chainId` from the `block` instead of reading it from the storage, the idea is to better handle the chain splits and keep the contracts operating.
- `block.chainid` (uint): current chain id -> https://docs.soliditylang.org/en/v0.8.0/units-and-global-variables.html#block-and-transaction-properties