### PR TITLE
feat: set DAO configs with Managing proposals

### DIFF
--- a/contracts/adapters/interfaces/IManaging.sol
+++ b/contracts/adapters/interfaces/IManaging.sol
@@ -35,6 +35,18 @@ interface IManaging {
         EXTENSION
     }
 
+    enum ConfigType {
+        NUMERIC,
+        ADDRESS
+    }
+
+    struct Configuration {
+        bytes32 key;
+        uint256 numericValue;
+        address addressValue;
+        ConfigType configType;
+    }
+
     struct ProposalDetails {
         bytes32 adapterOrExtensionId;
         address adapterOrExtensionAddr;
@@ -50,6 +62,7 @@ interface IManaging {
         DaoRegistry dao,
         bytes32 proposalId,
         ProposalDetails calldata proposal,
+        Configuration[] memory configs,
         bytes calldata data
     ) external;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "mocha": "^8.3.2",
         "npm": "^7.10.0",
         "prettier": "^2.2.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.3",
+        "prettier-plugin-solidity": "^1.0.0-beta.19",
         "solhint": "^3.3.2",
         "solidity-coverage": "^0.7.16",
         "truffle": "^5.3.2",
@@ -6426,6 +6426,12 @@
       "integrity": "sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==",
       "dev": true
     },
+    "node_modules/antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
+      "dev": true
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -9668,12 +9674,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dir-to-object": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-to-object/-/dir-to-object-2.0.0.tgz",
-      "integrity": "sha512-sXs0JKIhymON7T1UZuO2Ud6VTNAx/VTBXIl4+3mjb2RgfOpt+hectX0x04YqPOPdkeOAKoJuKqwqnXXURNPNEA==",
-      "dev": true
     },
     "node_modules/dns-over-http-resolver": {
       "version": "1.2.2",
@@ -27431,6 +27431,7 @@
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.0.2.tgz",
       "integrity": "sha512-Ib6ygFYBleS8x2gh3C1AkVsdrUShqXpe6jSTnZ6sRycEXKhqVf+xOSkhgSnjidpPzyv0d95LJVFrYQ4NuXAqHA==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "abstract-leveldown": "~6.0.0",
@@ -34185,9 +34186,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -34196,43 +34197,47 @@
       }
     },
     "node_modules/prettier-plugin-solidity": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.9.tgz",
-      "integrity": "sha512-Y7AEF17HaFAvEPMC6UESNQwjRs5+7TQQkG6j1OW5JdDlglFm1j0kLYaK6azKvIocsKlBvuvy5a3dZL+uK0pZhg==",
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.19.tgz",
+      "integrity": "sha512-xxRQ5ZiiZyUoMFLE9h7HnUDXI/daf1tnmL1msEdcKmyh7ZGQ4YklkYLC71bfBpYU2WruTb5/SFLUaEb3RApg5g==",
       "dev": true,
       "dependencies": {
-        "@solidity-parser/parser": "^0.12.1",
-        "dir-to-object": "^2.0.0",
-        "emoji-regex": "^9.2.2",
+        "@solidity-parser/parser": "^0.14.0",
+        "emoji-regex": "^10.0.0",
         "escape-string-regexp": "^4.0.0",
-        "prettier": "^2.2.1",
         "semver": "^7.3.5",
-        "solidity-comments-extractor": "^0.0.6",
-        "string-width": "^4.2.2"
+        "solidity-comments-extractor": "^0.0.7",
+        "string-width": "^4.2.3"
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "prettier": "^2.3.0"
       }
     },
     "node_modules/prettier-plugin-solidity/node_modules/@solidity-parser/parser": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.12.1.tgz",
-      "integrity": "sha512-ikxVpwskNxEp2fvYS1BdRImnevHmM97zdPFBa1cVtjtNpoqCm/EmljATTZk0s9G/zsN5ZbPf9OAIAW4gbBJiRA==",
-      "dev": true
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
+      "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
+      "dev": true,
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
     },
     "node_modules/prettier-plugin-solidity/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/prettier-plugin-solidity/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.0.0.tgz",
+      "integrity": "sha512-KmJa8l6uHi1HrBI34udwlzZY1jOEuID/ft4d8BSSEdRyap7PwBEt910453PJa5MuGvxkLqlt4Uvhu7tttFHViw==",
       "dev": true
     },
     "node_modules/prettier-plugin-solidity/node_modules/escape-string-regexp": {
@@ -34254,14 +34259,14 @@
       }
     },
     "node_modules/prettier-plugin-solidity/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -34274,12 +34279,12 @@
       "dev": true
     },
     "node_modules/prettier-plugin-solidity/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -36281,9 +36286,9 @@
       }
     },
     "node_modules/solidity-comments-extractor": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.6.tgz",
-      "integrity": "sha512-5GRv062LXC+8sJZS3wlY4ZptKFODf+jTDqxB64DWf/uyAL5ZJEvmr8wW3Kd/V+e5roBShcC15+ThfGMerF2Yxw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
+      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
       "dev": true
     },
     "node_modules/solidity-coverage": {
@@ -36571,6 +36576,7 @@
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.2.0.tgz",
       "integrity": "sha512-roEOz41hxui2Q7uYnWsjMOTry6TcNUNmp8audCx18gF10P2NknwdpF+E+HKvz/F2NvPKGGBF4NGc+ZPQ+AABwg==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "nan": "^2.12.1",
@@ -45925,6 +45931,12 @@
       "integrity": "sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==",
       "dev": true
     },
+    "antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
+      "dev": true
+    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -48825,12 +48837,6 @@
       "requires": {
         "path-type": "^4.0.0"
       }
-    },
-    "dir-to-object": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-to-object/-/dir-to-object-2.0.0.tgz",
-      "integrity": "sha512-sXs0JKIhymON7T1UZuO2Ud6VTNAx/VTBXIl4+3mjb2RgfOpt+hectX0x04YqPOPdkeOAKoJuKqwqnXXURNPNEA==",
-      "dev": true
     },
     "dns-over-http-resolver": {
       "version": "1.2.2",
@@ -70526,42 +70532,43 @@
       "optional": true
     },
     "prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA=="
     },
     "prettier-plugin-solidity": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.9.tgz",
-      "integrity": "sha512-Y7AEF17HaFAvEPMC6UESNQwjRs5+7TQQkG6j1OW5JdDlglFm1j0kLYaK6azKvIocsKlBvuvy5a3dZL+uK0pZhg==",
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.19.tgz",
+      "integrity": "sha512-xxRQ5ZiiZyUoMFLE9h7HnUDXI/daf1tnmL1msEdcKmyh7ZGQ4YklkYLC71bfBpYU2WruTb5/SFLUaEb3RApg5g==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.12.1",
-        "dir-to-object": "^2.0.0",
-        "emoji-regex": "^9.2.2",
+        "@solidity-parser/parser": "^0.14.0",
+        "emoji-regex": "^10.0.0",
         "escape-string-regexp": "^4.0.0",
-        "prettier": "^2.2.1",
         "semver": "^7.3.5",
-        "solidity-comments-extractor": "^0.0.6",
-        "string-width": "^4.2.2"
+        "solidity-comments-extractor": "^0.0.7",
+        "string-width": "^4.2.3"
       },
       "dependencies": {
         "@solidity-parser/parser": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.12.1.tgz",
-          "integrity": "sha512-ikxVpwskNxEp2fvYS1BdRImnevHmM97zdPFBa1cVtjtNpoqCm/EmljATTZk0s9G/zsN5ZbPf9OAIAW4gbBJiRA==",
-          "dev": true
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
+          "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
+          "dev": true,
+          "requires": {
+            "antlr4ts": "^0.5.0-alpha.4"
+          }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.0.0.tgz",
+          "integrity": "sha512-KmJa8l6uHi1HrBI34udwlzZY1jOEuID/ft4d8BSSEdRyap7PwBEt910453PJa5MuGvxkLqlt4Uvhu7tttFHViw==",
           "dev": true
         },
         "escape-string-regexp": {
@@ -70577,14 +70584,14 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           },
           "dependencies": {
             "emoji-regex": {
@@ -70596,12 +70603,12 @@
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -72311,9 +72318,9 @@
       }
     },
     "solidity-comments-extractor": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.6.tgz",
-      "integrity": "sha512-5GRv062LXC+8sJZS3wlY4ZptKFODf+jTDqxB64DWf/uyAL5ZJEvmr8wW3Kd/V+e5roBShcC15+ThfGMerF2Yxw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
+      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
       "dev": true
     },
     "solidity-coverage": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "^8.3.2",
     "npm": "^7.10.0",
     "prettier": "^2.2.1",
-    "prettier-plugin-solidity": "^1.0.0-beta.3",
+    "prettier-plugin-solidity": "^1.0.0-beta.19",
     "solhint": "^3.3.2",
     "solidity-coverage": "^0.7.16",
     "truffle": "^5.3.2",

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -714,7 +714,8 @@ describe("Adapter - GuildKick", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         { from: kickedMember, gasPrice: toBN("0") }
       ),
       "onlyMember"
@@ -785,7 +786,8 @@ describe("Adapter - GuildKick", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         { from: kickedMember, gasPrice: toBN("0") }
       ),
       "onlyMember"

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -31,6 +31,7 @@ const {
   GUILD,
   ZERO_ADDRESS,
   sha3,
+  DAI_TOKEN,
 } = require("../../utils/ContractUtil.js");
 
 const {
@@ -111,7 +112,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         { from: daoOwner, gasPrice: toBN("0") }
       ),
       "must be an equal number of config keys and values"
@@ -136,7 +138,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         { from: daoOwner, gasPrice: toBN("0") }
       ),
       "must be an equal number of config keys and values"
@@ -161,7 +164,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         { from: daoOwner, gasPrice: toBN("0") }
       ),
       "address is reserved"
@@ -181,7 +185,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         { from: daoOwner, gasPrice: toBN("0") }
       ),
       "address is reserved"
@@ -208,7 +213,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -258,7 +264,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       { from: daoOwner, gasPrice: toBN("0") }
     );
 
@@ -322,7 +329,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -343,7 +351,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         {
           from: daoOwner,
           gasPrice: toBN("0"),
@@ -377,7 +386,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -422,7 +432,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -472,7 +483,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -506,7 +518,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         {
           from: daoOwner,
           gasPrice: toBN("0"),
@@ -538,7 +551,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         { from: nonMember, gasPrice: toBN("0") }
       ),
       "onlyMember"
@@ -567,7 +581,8 @@ describe("Adapter - Managing", () => {
           extensionAddresses: [],
           extensionAclFlags: [],
         },
-        [],
+        [], //configs
+        [], //data
         {
           from: nonMemberAddress,
           gasPrice: toBN("0"),
@@ -598,7 +613,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -640,7 +656,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -682,7 +699,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -721,7 +739,8 @@ describe("Adapter - Managing", () => {
         extensionAddresses: [],
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -776,7 +795,8 @@ describe("Adapter - Managing", () => {
           }).flags,
         ],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -865,6 +885,82 @@ describe("Adapter - Managing", () => {
     ).equal(false);
   });
 
+  it("should be possible to add a new adapter with DAO configs", async () => {
+    const dao = this.dao;
+    const managing = this.adapters.managing;
+    const voting = this.adapters.voting;
+    const financing = await FinancingContract.new();
+    const bankExt = this.extensions.bank;
+
+    const newAdapterId = sha3("testFinancing");
+    const newAdapterAddress = financing.address;
+    const proposalId = getProposalCounter();
+
+    await managing.submitProposal(
+      dao.address,
+      proposalId,
+      {
+        adapterOrExtensionId: newAdapterId,
+        adapterOrExtensionAddr: newAdapterAddress,
+        updateType: 1,
+        flags: 0,
+        keys: [],
+        values: [],
+        // Set the extension address which will be accessed by the new adapter
+        extensionAddresses: [bankExt.address],
+        // Set the acl flags so the new adapter can access the bank extension
+        extensionAclFlags: [
+          entryBank(financing, {
+            ADD_TO_BALANCE: true,
+            SUB_FROM_BALANCE: true,
+            INTERNAL_TRANSFER: true,
+          }).flags,
+        ],
+      },
+      [
+        {
+          key: sha3("some.numeric.config"),
+          numericValue: 32,
+          addressValue: ZERO_ADDRESS,
+          configType: 0, //NUMERIC
+        },
+        {
+          key: sha3("some.address.config"),
+          numericValue: 0,
+          addressValue: DAI_TOKEN,
+          configType: 1, //ADDRESS
+        },
+      ], //configs
+      [], //data
+      {
+        from: daoOwner,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    await advanceTime(1000);
+
+    await managing.processProposal(dao.address, proposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    expect(await dao.getAdapterAddress(newAdapterId)).equal(newAdapterAddress);
+    const numericConfig = await dao.getConfiguration(
+      sha3("some.numeric.config")
+    );
+    expect(numericConfig.toString()).equal("32");
+    const addressConfig = await dao.getAddressConfiguration(
+      sha3("some.address.config")
+    );
+    expect(addressConfig.toLowerCase()).equal(DAI_TOKEN);
+  });
+
   it("should be possible to add a new extension", async () => {
     const dao = this.dao;
     const managing = this.adapters.managing;
@@ -890,7 +986,8 @@ describe("Adapter - Managing", () => {
         // Set the acl flags so the new adapter can access the bank extension
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -912,6 +1009,77 @@ describe("Adapter - Managing", () => {
     expect(await dao.getExtensionAddress(newExtensionId)).equal(
       newExtensionAddr
     );
+  });
+
+  it("should be possible to add a new extension with DAO configs", async () => {
+    const dao = this.dao;
+    const managing = this.adapters.managing;
+    const voting = this.adapters.voting;
+    const nftExt = await NFTExtension.new();
+
+    const newExtensionId = sha3("testNewExtension");
+    const newExtensionAddr = nftExt.address;
+    const proposalId = getProposalCounter();
+
+    await managing.submitProposal(
+      dao.address,
+      proposalId,
+      {
+        adapterOrExtensionId: newExtensionId,
+        adapterOrExtensionAddr: newExtensionAddr,
+        updateType: 2, // 1 = Adapter, 2 = Extension
+        flags: 0,
+        keys: [],
+        values: [],
+        // Set the extension address which will be accessed by the new adapter
+        extensionAddresses: [],
+        // Set the acl flags so the new adapter can access the bank extension
+        extensionAclFlags: [],
+      },
+      [
+        {
+          key: sha3("some.numeric.config"),
+          numericValue: 32,
+          addressValue: ZERO_ADDRESS,
+          configType: 0, //NUMERIC
+        },
+        {
+          key: sha3("some.address.config"),
+          numericValue: 0,
+          addressValue: DAI_TOKEN,
+          configType: 1, //ADDRESS
+        },
+      ], //configs
+      [], //data
+      {
+        from: daoOwner,
+        gasPrice: toBN("0"),
+      }
+    );
+
+    await voting.submitVote(dao.address, proposalId, 1, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    await advanceTime(1000);
+
+    await managing.processProposal(dao.address, proposalId, {
+      from: daoOwner,
+      gasPrice: toBN("0"),
+    });
+
+    expect(await dao.getExtensionAddress(newExtensionId)).equal(
+      newExtensionAddr
+    );
+    const numericConfig = await dao.getConfiguration(
+      sha3("some.numeric.config")
+    );
+    expect(numericConfig.toString()).equal("32");
+    const addressConfig = await dao.getAddressConfiguration(
+      sha3("some.address.config")
+    );
+    expect(addressConfig.toLowerCase()).equal(DAI_TOKEN);
   });
 
   it("should be possible to remove an extension", async () => {
@@ -939,7 +1107,8 @@ describe("Adapter - Managing", () => {
         // Set the acl flags so the new adapter can access the bank extension
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),
@@ -989,7 +1158,8 @@ describe("Adapter - Managing", () => {
         // Set the acl flags so the new adapter can access the bank extension
         extensionAclFlags: [],
       },
-      [],
+      [], //configs
+      [], //data
       {
         from: daoOwner,
         gasPrice: toBN("0"),

--- a/test/extensions/nft.test.js
+++ b/test/extensions/nft.test.js
@@ -70,10 +70,7 @@ describe("Extension - NFT", () => {
   it("should not be possible get an NFT in the collection if it is empty", async () => {
     const nftExtension = this.extensions.nft;
     const pixelNFT = this.testContracts.pixelNFT;
-    await expectRevert(
-      nftExtension.getNFT(pixelNFT.address, 0),
-      "index out of bounds"
-    );
+    await expectRevert(nftExtension.getNFT(pixelNFT.address, 0), "revert");
   });
 
   it("should not be possible to return a NFT without the RETURN permission", async () => {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -73,7 +73,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.0", // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.10", // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       settings: {
         // See the solidity docs for advice about optimization and evmVersion

--- a/utils/DeploymentUtil.js
+++ b/utils/DeploymentUtil.js
@@ -491,6 +491,7 @@ const configureDao = async ({
         REPLACE_ADAPTER: true,
         ADD_EXTENSION: true,
         REMOVE_EXTENSION: true,
+        SET_CONFIGURATION: true,
       }),
       entryDao("financing", financing, {
         SUBMIT_PROPOSAL: true,


### PR DESCRIPTION
## Proposed Changes

- Managing adapter was updated to support DAO configs (`address` and/or `numeric types)
- Solc compiler version bumped to `0.8.10`
- Managing adapter requires a new ACL Flag: `SET_CONFIGURATION`
- Fixed tests
- bump prettier-plugin-solidity" to v1.0.0-beta.19

Once merged, this commit will be cherry picked to `master` branch.