### PR TITLE
chore: bump oz-contracts to v4.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "2.2.4",
       "license": "MIT",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.1.0",
+        "@openzeppelin/contracts": "^4.3.3",
         "@truffle/contract": "^4.3.13",
         "@truffle/hdwallet-provider": "1.2.2",
         "chalk": "^4.1.2",
@@ -5187,9 +5187,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
-      "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg=="
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.3.tgz",
+      "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g=="
     },
     "node_modules/@openzeppelin/test-environment": {
       "version": "0.1.9",
@@ -54679,9 +54679,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
-      "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg=="
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.3.tgz",
+      "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g=="
     },
     "@openzeppelin/test-environment": {
       "version": "0.1.9",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.1.0",
+    "@openzeppelin/contracts": "4.3.3",
     "@truffle/contract": "^4.3.13",
     "@truffle/hdwallet-provider": "1.2.2",
     "chalk": "^4.1.2",

--- a/subgraph/package-lock.json
+++ b/subgraph/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.0.0-beta.0",
+        "@openzeppelin/contracts": "4.3.3",
         "@truffle/hdwallet-provider": "1.2.2",
         "@typechain/ethers-v5": "^6.0.2",
         "eth-sig-util": "^3.0.0",
@@ -4036,9 +4036,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.1.0.tgz",
-      "integrity": "sha512-TihZitscnaHNcZgXGj9zDLDyCqjziytB4tMCwXq0XimfWkAjBYyk5/pOsDbbwcavhlc79HhpTEpQcrMnPVa1mw=="
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.3.tgz",
+      "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -39280,9 +39280,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.1.0.tgz",
-      "integrity": "sha512-TihZitscnaHNcZgXGj9zDLDyCqjziytB4tMCwXq0XimfWkAjBYyk5/pOsDbbwcavhlc79HhpTEpQcrMnPVa1mw=="
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.3.tgz",
+      "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.0.0-beta.0",
+    "@openzeppelin/contracts": "4.3.3",
     "@truffle/hdwallet-provider": "1.2.2",
     "@typechain/ethers-v5": "^6.0.2",
     "eth-sig-util": "^3.0.0",


### PR DESCRIPTION
## Proposed Changes

- Bump oz contracts from 4.1.0 to v4.3.3 in package.json
- Bump oz contracts from 4.0.0-beta-0 to v4.3.3 in subgraph/package.json

The breaking changes do not affect the contracts that we are currently using.

https://github.com/OpenZeppelin/openzeppelin-contracts/releases
