### PR TITLE
WIP feat: governance roles based on tokens

### DIFF
--- a/contracts/adapters/Configuration.sol
+++ b/contracts/adapters/Configuration.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 
 import "../core/DaoRegistry.sol";
 import "../guards/AdapterGuard.sol";
+import "../guards/GovernanceGuard.sol";
 import "./interfaces/IConfiguration.sol";
 import "../adapters/interfaces/IVoting.sol";
 import "../helpers/DaoHelper.sol";
@@ -32,7 +33,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-contract ConfigurationContract is IConfiguration, AdapterGuard {
+contract ConfigurationContract is
+    IConfiguration,
+    AdapterGuard,
+    GovernanceGuard
+{
     mapping(address => mapping(bytes32 => Configuration[]))
         private _configurations;
 
@@ -49,7 +54,12 @@ contract ConfigurationContract is IConfiguration, AdapterGuard {
         bytes32 proposalId,
         Configuration[] calldata configs,
         bytes calldata data
-    ) external override reentrancyGuard(dao) {
+    )
+        external
+        override
+        reentrancyGuard(dao)
+        onlyGovernor(dao, DaoHelper.CONFIGURATION_GOVERNOR)
+    {
         require(configs.length > 0, "missing configs");
 
         dao.submitProposal(proposalId);
@@ -93,6 +103,7 @@ contract ConfigurationContract is IConfiguration, AdapterGuard {
         external
         override
         reentrancyGuard(dao)
+        onlyGovernor(dao, DaoHelper.CONFIGURATION_GOVERNOR)
     {
         dao.processProposal(proposalId);
 

--- a/contracts/adapters/Managing.sol
+++ b/contracts/adapters/Managing.sol
@@ -6,6 +6,7 @@ import "./interfaces/IManaging.sol";
 import "../core/DaoRegistry.sol";
 import "../adapters/interfaces/IVoting.sol";
 import "../guards/AdapterGuard.sol";
+import "../guards/GovernanceGuard.sol";
 import "../helpers/DaoHelper.sol";
 
 /**
@@ -32,7 +33,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-contract ManagingContract is IManaging, AdapterGuard {
+contract ManagingContract is IManaging, AdapterGuard, GovernanceGuard {
     mapping(address => mapping(bytes32 => ProposalDetails)) public proposals;
 
     /**
@@ -52,7 +53,12 @@ contract ManagingContract is IManaging, AdapterGuard {
         bytes32 proposalId,
         ProposalDetails calldata proposal,
         bytes calldata data
-    ) external override reentrancyGuard(dao) {
+    )
+        external
+        override
+        reentrancyGuard(dao)
+        onlyGovernor(dao, DaoHelper.MANAGING_GOVERNOR)
+    {
         require(
             proposal.keys.length == proposal.values.length,
             "must be an equal number of config keys and values"
@@ -103,6 +109,7 @@ contract ManagingContract is IManaging, AdapterGuard {
         external
         override
         reentrancyGuard(dao)
+        onlyGovernor(dao, DaoHelper.MANAGING_GOVERNOR)
     {
         ProposalDetails memory proposal = proposals[address(dao)][proposalId];
 

--- a/contracts/guards/GovernanceGuard.sol
+++ b/contracts/guards/GovernanceGuard.sol
@@ -1,0 +1,86 @@
+pragma solidity ^0.8.0;
+
+// SPDX-License-Identifier: MIT
+
+import "../core/DaoRegistry.sol";
+import "../extensions/bank/Bank.sol";
+import "../helpers/DaoHelper.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+// import "@openzeppelin/contracts/token/ERC1155/IERC1555.sol";
+
+/**
+MIT License
+
+Copyright (c) 2020 Openlaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+abstract contract GovernanceGuard {
+    modifier onlyGovernor(DaoRegistry dao, bytes32 governorRole) {
+        _onlyGovernorMember(dao, msg.sender, governorRole);
+        _;
+    }
+
+    function _onlyGovernorMember(
+        DaoRegistry dao,
+        address memberAddr,
+        bytes32 governorRole
+    ) internal view {
+        require(
+            isActiveGovernor(dao, memberAddr, governorRole),
+            "onlyGovernor"
+        );
+    }
+
+    /**
+     * @dev Checks if the member address holds enough funds to be considered a governor.
+     * @param dao The DAO Address.
+     * @param memberAddr The message sender to be verified as governor.
+     * @param governorRole The role config of the adapter or extension to retrieve the governance token address.
+     */
+    function isActiveGovernor(
+        DaoRegistry dao,
+        address memberAddr,
+        bytes32 governorRole
+    ) public view returns (bool) {
+        address governanceToken = dao.getAddressConfiguration(governorRole);
+        require(
+            DaoHelper.isNotZeroAddress(governanceToken),
+            "missing governance token config"
+        );
+
+        address bankAddress = dao.extensions(DaoHelper.BANK);
+        if (DaoHelper.isNotZeroAddress(bankAddress)) {
+            address delegatedMemberAddr = dao.getAddressIfDelegated(memberAddr);
+
+            BankExtension bank = BankExtension(bankAddress);
+            if (bank.isInternalToken(governanceToken)) {
+                return bank.balanceOf(delegatedMemberAddr, governanceToken) > 0;
+            } else {
+                //TODO check for ERC721, ERC1155?
+                return
+                    IERC20(governanceToken).balanceOf(delegatedMemberAddr) > 0;
+            }
+        }
+
+        return dao.isMember(memberAddr);
+    }
+}

--- a/contracts/helpers/DaoHelper.sol
+++ b/contracts/helpers/DaoHelper.sol
@@ -28,7 +28,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 library DaoHelper {
-    // Adapters
+    /*
+     * Adapters Ids
+     */
     bytes32 internal constant VOTING = keccak256("voting");
     bytes32 internal constant ONBOARDING = keccak256("onboarding");
     bytes32 internal constant NONVOTING_ONBOARDING =
@@ -59,7 +61,9 @@ library DaoHelper {
     bytes32 internal constant ERC20_TRANSFER_STRATEGY_ADPT =
         keccak256("erc20-transfer-strategy");
 
-    // Extensions
+    /*
+     * Extensions Ids
+     */
     bytes32 internal constant BANK = keccak256("bank");
     bytes32 internal constant ERC1271 = keccak256("erc1271");
     bytes32 internal constant NFT = keccak256("nft");
@@ -69,7 +73,9 @@ library DaoHelper {
     bytes32 internal constant ERC1155_EXT = keccak256("erc1155-ext");
     bytes32 internal constant ERC20_EXT = keccak256("erc20-ext");
 
-    // Reserved Addresses
+    /*
+     * Reserved Addresses
+     */
     address internal constant GUILD = address(0xdead);
     address internal constant ESCROW = address(0x4bec);
     address internal constant TOTAL = address(0xbabe);
@@ -80,7 +86,25 @@ library DaoHelper {
     address internal constant ETH_TOKEN = address(0x0);
     address internal constant MEMBER_COUNT = address(0xDECAFBAD);
 
+    /*
+     * Global Constants
+     */
+
+    // The maximum number of tokens supported in the Guild Bank.
     uint8 internal constant MAX_TOKENS_GUILD_BANK = 200;
+
+    /*
+     * Governor Config Roles
+     */
+    // Indicates the name of the dao config that must be read to get the token
+    // address that grants the access to the Configuration Adapter.
+    bytes32 internal constant CONFIGURATION_GOVERNOR =
+        keccak256("governor.role.configuration");
+
+    // Indicates the name of the dao config that must be read to get the token
+    // address that grants the access to the Managing Adapter.
+    bytes32 internal constant MANAGING_GOVERNOR =
+        keccak256("governor.role.managing");
 
     function totalTokens(BankExtension bank) internal view returns (uint256) {
         return memberTokens(bank, TOTAL) - memberTokens(bank, GUILD); //GUILD is accounted for twice otherwise

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -15,6 +15,7 @@ const {
 
 const { deployDao, getNetworkDetails } = require("../utils/deployment-util");
 const { deployConfigs } = require("../deploy-config");
+const { governanceRoles } = require("../utils/access-control-util");
 require("dotenv").config();
 
 module.exports = async (deployer, network, accounts) => {
@@ -113,6 +114,8 @@ const deployRinkebyDao = async (
     supplyPixelNFT: 100,
     supplyOLToken: toBN("1000000000000000000000000"),
     erc1155TestTokenUri: "1155 test token",
+    [governanceRoles.MANAGING_GOVERNOR]: UNITS,
+    [governanceRoles.CONFIGURATION_GOVERNOR]: UNITS,
   });
 };
 
@@ -208,6 +211,8 @@ const deployGanacheDao = async (
     supplyPixelNFT: 100,
     supplyOLToken: toBN("1000000000000000000000000"),
     erc1155TestTokenUri: "1155 test token",
+    [governanceRoles.MANAGING_GOVERNOR]: UNITS,
+    [governanceRoles.CONFIGURATION_GOVERNOR]: UNITS,
   });
 };
 
@@ -251,6 +256,8 @@ const deployTestDao = async (
     offchainAdmin: daoOwnerAddress,
     daoName: envVars.DAO_NAME,
     owner: accounts[0],
+    [governanceRoles.MANAGING_GOVERNOR]: UNITS,
+    [governanceRoles.CONFIGURATION_GOVERNOR]: UNITS,
   });
 };
 
@@ -342,6 +349,8 @@ const deployHarmonyTestDao = async (
       "OFFCHAIN_ADMIN_ADDR",
       envVars.DAO_OWNER_ADDR
     ),
+    [governanceRoles.MANAGING_GOVERNOR]: UNITS,
+    [governanceRoles.CONFIGURATION_GOVERNOR]: UNITS,
   });
 };
 

--- a/migrations/configs/contracts.config.ts
+++ b/migrations/configs/contracts.config.ts
@@ -14,6 +14,7 @@ import {
   entryVesting,
   ACLBuilder,
   SelectedACLs,
+  governanceRoles,
 } from "../../utils/access-control-util";
 
 import { extensionsIdsMap, adaptersIdsMap } from "../../utils/dao-ids-util";
@@ -68,7 +69,7 @@ export type ContractConfig = {
    */
   skipAutoDeploy?: boolean;
   /**
-   * Version of the solidity contract. 
+   * Version of the solidity contract.
    * It needs to be the name of the contract, and not the name of the .sol file.
    */
   version: string;
@@ -107,6 +108,18 @@ export type ContractConfig = {
    * set the extensionsIdsMap.BANK_EXT in this attribute to indicate it generates bank contracts.
    */
   generatesExtensionId?: string;
+
+  /**
+   * Optional
+   * The governor roles defined in the DaoHelper and verified using GovernanceGuard.onlyGovernor.
+   * A role is essentially a DAO config, and the config is read by the GovernanceGuard.
+   * If not present in the DAO Registry it will revert with an error, otherwise it will verify
+   * if the caller is allowed to execute the call.
+   * Roles are used to limit the access to a given member by checking which token the member holds.
+   * So the DAO members can decide and set the configuration with the internal or external token address
+   * that indicates the access to a given resource.
+   */
+  roles?: Array<String>;
 };
 
 export const contracts: Array<ContractConfig> = [
@@ -316,8 +329,7 @@ export const contracts: Array<ContractConfig> = [
     id: "vesting-extension-factory",
     name: "InternalTokenVestingExtensionFactory",
     alias: "vestingExtFactory",
-    path:
-      "../../contracts/extensions/token/erc20/InternalTokenVestingExtensionFactory",
+    path: "../../contracts/extensions/token/erc20/InternalTokenVestingExtensionFactory",
     enabled: true,
     version: "1.0.0",
     type: ContractType.Factory,
@@ -427,8 +439,7 @@ export const contracts: Array<ContractConfig> = [
     id: extensionsIdsMap.VESTING_EXT,
     name: "InternalTokenVestingExtension",
     alias: "vestingExt",
-    path:
-      "../../contracts/extensions/token/erc20/InternalTokenVestingExtension",
+    path: "../../contracts/extensions/token/erc20/InternalTokenVestingExtension",
     enabled: true,
     version: "1.0.0",
     type: ContractType.Extension,
@@ -549,6 +560,7 @@ export const contracts: Array<ContractConfig> = [
       ],
       extensions: {},
     },
+    roles: [governanceRoles.CONFIGURATION_GOVERNOR],
   },
   {
     id: adaptersIdsMap.ERC1155_ADAPTER,
@@ -591,6 +603,7 @@ export const contracts: Array<ContractConfig> = [
       ],
       extensions: {},
     },
+    roles: [governanceRoles.MANAGING_GOVERNOR],
   },
 
   // Signature Adapters

--- a/test/adapters/guildkick.test.js
+++ b/test/adapters/guildkick.test.js
@@ -721,7 +721,7 @@ describe("Adapter - GuildKick", () => {
         [],
         { from: kickedMember, gasPrice: toBN("0") }
       ),
-      "onlyMember"
+      "onlyGovernor"
     );
   });
 
@@ -773,15 +773,15 @@ describe("Adapter - GuildKick", () => {
 
     const proposalId = getProposalCounter();
     //Submit a new Bank adapter proposal
-    let newadapterId = sha3("onboarding");
-    let newadapterAddress = accounts[3]; //TODO deploy some Banking test contract
+    let newAdapterId = sha3("onboarding");
+    let newAdapterAddress = accounts[3]; //TODO deploy some Banking test contract
     await expectRevert(
       managing.submitProposal(
         this.dao.address,
         proposalId,
         {
-          adapterOrExtensionId: newadapterId,
-          adapterOrExtensionAddr: newadapterAddress,
+          adapterOrExtensionId: newAdapterId,
+          adapterOrExtensionAddr: newAdapterAddress,
           updateType: 1,
           flags: 0,
           keys: [],
@@ -792,7 +792,7 @@ describe("Adapter - GuildKick", () => {
         [],
         { from: kickedMember, gasPrice: toBN("0") }
       ),
-      "onlyMember"
+      "onlyGovernor"
     );
   });
 

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -543,7 +543,7 @@ describe("Adapter - Managing", () => {
     );
   });
 
-  it("should not be possible for a non member to propose a new adapter", async () => {
+  it("should not be possible for a non governor to propose a new adapter", async () => {
     const dao = this.dao;
     const managing = this.adapters.managing;
     const nonMember = accounts[3];
@@ -568,11 +568,11 @@ describe("Adapter - Managing", () => {
         [],
         { from: nonMember, gasPrice: toBN("0") }
       ),
-      "onlyMember"
+      "onlyGovernor"
     );
   });
 
-  it("should not be possible for a non member to submit a proposal", async () => {
+  it("should not be possible for a non governor to submit a proposal", async () => {
     const dao = this.dao;
     const managing = this.adapters.managing;
     const nonMemberAddress = accounts[5];
@@ -600,11 +600,11 @@ describe("Adapter - Managing", () => {
           gasPrice: toBN("0"),
         }
       ),
-      "onlyMember"
+      "onlyGovernor"
     );
   });
 
-  it("should be possible for a non member to process a proposal", async () => {
+  it("should not be possible for a non governor to process a proposal", async () => {
     const dao = this.dao;
     const managing = this.adapters.managing;
     const voting = this.adapters.voting;
@@ -639,13 +639,13 @@ describe("Adapter - Managing", () => {
 
     await advanceTime(1000);
 
-    await managing.processProposal(dao.address, proposalId, {
-      from: nonMember,
-      gasPrice: toBN("0"),
-    });
-
-    const processedFlag = 2;
-    expect(await dao.getProposalFlag(proposalId, processedFlag)).equal(true);
+    await expectRevert(
+      managing.processProposal(dao.address, proposalId, {
+        from: nonMember,
+        gasPrice: toBN("0"),
+      }),
+      "onlyGovernor"
+    );
   });
 
   it("should not be possible to process a proposal if the voting did not pass", async () => {

--- a/test/extensions/erc20.test.js
+++ b/test/extensions/erc20.test.js
@@ -1,7 +1,6 @@
 // Whole-script strict mode syntax
 "use strict";
 
-const { sha3 } = require("web3-utils");
 /**
 MIT License
 
@@ -31,6 +30,7 @@ const {
   UNITS,
   ZERO_ADDRESS,
   numberOfUnits,
+  sha3,
 } = require("../../utils/contract-util");
 
 const {
@@ -60,7 +60,9 @@ describe("Extension - ERC20", () => {
 
   before("deploy dao", async () => {
     const { dao, adapters, extensions, testContracts } = await deployDefaultDao(
-      { owner: daoOwner }
+      {
+        owner: daoOwner,
+      }
     );
     this.dao = dao;
     this.adapters = adapters;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -80,7 +80,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.9", // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.10", // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       settings: {
         // See the solidity docs for advice about optimization and evmVersion

--- a/utils/access-control-util.ts
+++ b/utils/access-control-util.ts
@@ -243,3 +243,12 @@ export const calculateFlagValue = (values: Array<boolean>): number => {
     .map((v, idx) => (v === true ? 2 ** idx : 0))
     .reduce((a, b) => a + b);
 };
+
+/**
+ * The roles defined here are matching the roles available in the DaoHelper.sol,
+ * otherwise the roles won't work.
+ */
+export const governanceRoles: Record<string, string> = {
+  CONFIGURATION_GOVERNOR: "governor.role.configuration",
+  MANAGING_GOVERNOR: "governor.role.managing",
+};

--- a/utils/oz-util.js
+++ b/utils/oz-util.js
@@ -49,6 +49,7 @@ const {
   contracts: allContractConfigs,
 } = require("../migrations/configs/test.config");
 const { ContractType } = require("../migrations/configs/contracts.config");
+const { governanceRoles } = require("./access-control-util");
 
 const deployFunction = async (contractInterface, args, from) => {
   if (!contractInterface) throw Error("undefined contract interface");
@@ -212,6 +213,8 @@ module.exports = (() => {
       ...ozContracts,
       deployFunction,
       contractConfigs: allContractConfigs,
+      [governanceRoles.MANAGING_GOVERNOR]: UNITS,
+      [governanceRoles.CONFIGURATION_GOVERNOR]: UNITS,
     });
   };
 
@@ -223,6 +226,8 @@ module.exports = (() => {
         deployFunction,
         finalize: false,
         contractConfigs: allContractConfigs,
+        [governanceRoles.MANAGING_GOVERNOR]: UNITS,
+        [governanceRoles.CONFIGURATION_GOVERNOR]: UNITS,
       });
 
     await dao.finalizeDao({ from: owner });
@@ -246,6 +251,8 @@ module.exports = (() => {
         offchainVoting: true,
         offchainAdmin: owner,
         contractConfigs: allContractConfigs,
+        [governanceRoles.MANAGING_GOVERNOR]: UNITS,
+        [governanceRoles.CONFIGURATION_GOVERNOR]: UNITS,
       });
 
     await dao.potentialNewMember(newMember, {


### PR DESCRIPTION
## Proposed Changes
- A draft PR that suggests an approach to manage the access control based on governance tokens.
- New guard: GovernanceGuard to check if a given sender has the governor role that grants the access to execute a contract function.
- Updated configs, deployment script, and tests to set the governor roles 
- Updated Managing & Configuration adapters to restrict the access to `submitProposal` and `processProposals` functions, only governors should be allowed to call these functions.
