### PR TITLE
use rinkeby as default for local dev

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,6 +64,9 @@
    ```
    ###### Docker Compose env vars ######
 
+   # Configure the UI to use the Rinkeby network for local development
+   REACT_APP_DEFAULT_CHAIN_NAME_LOCAL=RINKEBY
+
    # It can be the same value you used for the Tribute DAO deployment.
    REACT_APP_INFURA_PROJECT_ID_DEV=INFURA_API_KEY
 

--- a/subgraph/config/subgraph-config.json
+++ b/subgraph/config/subgraph-config.json
@@ -1,6 +1,6 @@
 [
   {
-    "network": "ganache",
+    "network": "rinkeby",
     "daoFactoryAddress": "0x2612Af3A521c2df9EAF28422Ca335b04AdF3ac66",
     "daoFactoryStartBlock": 13,
     "GITHUB_USERNAME": "openlawteam",


### PR DESCRIPTION
Fixes [UI defaulting to ganache during local development](https://discord.com/channels/854328535929192498/854808091165196318/923312275765481532)

## Proposed Changes
- set `REACT_APP_DEFAULT_CHAIN_NAME_LOCAL` in the suggested `.env` file to use Rinkeby network
- set network in default `subgraph-config.json` to Rinkeby since current deployment instructions are for Rinkeby
