### PR TITLE
use rinkeby as default for local dev (web documentation)

### DIFF
--- a/website/docs/tutorial/dao/TributeUI.md
+++ b/website/docs/tutorial/dao/TributeUI.md
@@ -26,6 +26,9 @@ First, set the `tribute-ui` env vars in the `tribute-contracts/.env` file, just 
 # Paste it after the DAO env vars declared in the previous sections, these env vars are used by the services launched with Docker Compose.
 ######
 
+# Configure the UI to use the Rinkeby network for local development
+REACT_APP_DEFAULT_CHAIN_NAME_LOCAL=RINKEBY
+
 # It can be the same value you used for the Tribute DAO deployment.
 # Replace "your-api-key" with your Infura key
 REACT_APP_INFURA_PROJECT_ID_DEV=your-api-key


### PR DESCRIPTION
Fixes [UI defaulting to Ganache during local development](https://discord.com/channels/854328535929192498/854808091165196318/923312275765481532)

## Proposed Changes
- set REACT_APP_DEFAULT_CHAIN_NAME_LOCAL in the suggested .env file to use Rinkeby network
