### PR TITLE
fix: several fixes to make it work with tribute-ui

### DIFF
--- a/contracts/adapters/modifiers/ReimbursableLib.sol
+++ b/contracts/adapters/modifiers/ReimbursableLib.sol
@@ -37,16 +37,19 @@ library ReimbursableLib {
         data.gasStart = gasleft();
         require(dao.lockedAt() != block.number, "reentrancy guard");
         dao.lockSession();
-        data.reimbursement = IReimbursement(
-            dao.getAdapterAddress(DaoHelper.REIMBURSEMENT)
-        );
+        address reimbursementAdapter = dao.adapters(DaoHelper.REIMBURSEMENT);
+        if (reimbursementAdapter == address(0x0)) {
+            data.shouldReimburse = false;
+        } else {
+            data.reimbursement = IReimbursement(reimbursementAdapter);
 
-        (bool shouldReimburse, uint256 spendLimitPeriod) = data
-            .reimbursement
-            .shouldReimburse(dao, data.gasStart);
+            (bool shouldReimburse, uint256 spendLimitPeriod) = data
+                .reimbursement
+                .shouldReimburse(dao, data.gasStart);
 
-        data.shouldReimburse = shouldReimburse;
-        data.spendLimitPeriod = spendLimitPeriod;
+            data.shouldReimburse = shouldReimburse;
+            data.spendLimitPeriod = spendLimitPeriod;
+        }
     }
 
     function afterExecution(

--- a/contracts/guards/MemberGuard.sol
+++ b/contracts/guards/MemberGuard.sol
@@ -48,7 +48,7 @@ abstract contract MemberGuard {
     }
 
     function isActiveMember(DaoRegistry dao, address _addr)
-        internal
+        public
         view
         returns (bool)
     {

--- a/contracts/helpers/OffchainVotingHelper.sol
+++ b/contracts/helpers/OffchainVotingHelper.sol
@@ -127,11 +127,8 @@ contract OffchainVotingHelperContract {
         if (node.index >= nbMembers) {
             return BadNodeError.INDEX_OUT_OF_BOUND;
         }
-        //return 1 if yes, 2 if no and 0 if the vote is incorrect
-        address voter = dao.getPriorDelegateKey(
-            dao.getMemberAddress(node.index),
-            blockNumber
-        );
+
+        address memberAddr = dao.getMemberAddress(node.index);
 
         //invalid choice
         if (
@@ -157,7 +154,7 @@ contract OffchainVotingHelperContract {
             !_ovHash.hasVoted(
                 dao,
                 actionId,
-                voter,
+                dao.getPriorDelegateKey(memberAddr, blockNumber),
                 node.timestamp,
                 node.proposalId,
                 node.choice,
@@ -171,7 +168,7 @@ contract OffchainVotingHelperContract {
         if (
             GovernanceHelper.getVotingWeight(
                 dao,
-                voter,
+                memberAddr, // always check the weight of the member, not the delegate
                 node.proposalId,
                 blockNumber
             ) == 0

--- a/migrations/configs/contracts.config.ts
+++ b/migrations/configs/contracts.config.ts
@@ -800,7 +800,7 @@ export const contracts: Array<ContractConfig> = [
     name: "ReimbursementContract",
     alias: "reimbursement",
     path: "../../contracts/companion/ReimbursementContract",
-    enabled: true,
+    enabled: false,
     version: "1.0.0",
     type: ContractType.Adapter,
     deploymentArgs: ["gelato"],

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "deploy:goerli": "truffle deploy --network goerli --reset 2>&1 | tee logs/goerli-deploy_`date '+%F_%T'`.log",
     "deploy:harmony": "truffle deploy --network harmony --reset 2>&1 | tee logs/harmony-deploy_`date '+%F_%T'`.log",
     "deploy:harmonytest": "truffle deploy --network harmonytest --reset 2>&1 | tee logs/harmonytest-deploy_`date '+%F_%T'`.log",
-    "ganache": "ganache-cli --deterministic -p 7545 --networkId 1337",
+    "ganache": "ganache-cli --deterministic -p 7545 --networkId 1337 --chainId 1337 --hostname 0.0.0.0",
     "ganache:fork": "ganache-cli --deterministic -f ",
     "lint": "prettier --list-different 'contracts/**/*.sol' '**/*.js' '**/*.md'",
     "lint:fix": "prettier --write 'contracts/**/*.sol' '**/*.js' '**/*.md'",

--- a/scripts/coverage.ts
+++ b/scripts/coverage.ts
@@ -24,6 +24,10 @@ const skipFiles = [
   "test/TestToken1.sol",
   "test/TestToken2.sol",
   "utils/Multicall.sol",
+  "companion/interfaces/IReimbursement.sol",
+  "companion/GelatoBytes.sol",
+  "companion/Gelatofied.sol",
+  "companion/GelatoRelay.sol",
 ];
 
 const main = async () => {

--- a/test/adapters/offchain.voting.test.js
+++ b/test/adapters/offchain.voting.test.js
@@ -913,4 +913,5 @@ describe("Adapter - Offchain Voting", () => {
       "getPriorAmount not implemented"
     );
   });
+  //TODO create a proposal, vote, and submit the result using a delegated address - PASS
 });


### PR DESCRIPTION
These fixes were applied to release-v2.3.1, and now we need to make sure we have this on master branch as well.

## Proposed Changes

- `ReimbursableLib.sol `: check if the adapter is configured in the DAO, if not then the reimbursement is disabled by default.
-  `MemberGuard.sol`: function `isActiveMember` changed back to `public` (useful for tribute-ui)
- `OffchainVotingHelper.sol `: function call `GovernanceHelper.getVotingWeight` triggered from `getBadNodeError` function was fixed to consider the member address instead of the delegated address to check the voting weight. The reason for that is: if a member delegate the vote to a different address, the member needs to vote/submit the vote result using the delegate address, so we don't need to execute the `dao.getPriorDelegateKey(memberAddr, blockNumber)`, and then the GovernanceHelper will trigger the `getPriorAmount` call for that delegate address at a given block. 
