### PR TITLE
docs: updated tutorial to use release-v2.3.2

### DIFF
--- a/docker/README-ganache.md
+++ b/docker/README-ganache.md
@@ -1,0 +1,143 @@
+### Launching a DAO
+
+1. Checkout tribute-contracts branch `release-v1.0.6`
+
+   - > git fetch origin release-v1.0.6
+   - > git checkout release-v1.0.6
+
+2. Set the env vars in the root of `tribute-contracts` project
+
+   ```
+   ###### Tribute Contracts env vars ######
+
+   # Set the name of your DAO.
+   DAO_NAME=My First DAO
+
+   # The public ethereum address that belongs to the Owner of the DAO,
+   # in this case, it is your public ethereum address on Rinkeby network.
+   # Make sure you have some ETH, otherwise the deployment will fail.
+   DAO_OWNER_ADDR=0x...
+
+   # You can set that to use the same address you have in the DAO_OWNER_ADDR
+   COUPON_CREATOR_ADDR=0x...
+   KYC_COUPON_CREATOR_ADDR=0x...
+
+   # The name of the ERC20 token of your DAO.
+   ERC20_TOKEN_NAME=My First DAO Token
+
+   # The symbol of your ERC20 Token that will be used to control the
+   # DAO units that each member holds.
+   ERC20_TOKEN_SYMBOL=TDAO
+
+   # Number of decimals to display the token units in MM. We usually
+   # set 0 because the DAO units are managed in WEI, and to be able
+   # to see that in the MM wallet you need to remove the precision.
+   ERC20_TOKEN_DECIMALS=0
+
+   # The Ethereum Node URL to connect the Ethereum network. You can follow
+   # these steps to get your ProjectId/API Key from Infura:
+   # https://blog.infura.io/getting-started-with-infura-28e41844cc89/
+   # Or can use the default one from OpenLaw team, or set your own Infura/Alchemy API keys
+   ETH_NODE_URL=http://localhost:7545
+
+   # The 12 word "secret recovery phrase" for the ethereum address
+   # referenced in DAO_OWNER_ADDR above. This can be found in your wallet.
+   # It will be used to create the HD wallet and sign transactions on your behalf.
+   TRUFFLE_MNEMONIC=...
+
+   ###### Subgraph env vars ######
+
+   # Set it to true if you want to deploy the subgraph to the TheGraph.com API.
+   # Usually we leave it disabled because we deploy to a local Graph Node
+   # created in docker/docker-compose.yml file.
+   REMOTE_GRAPH_NODE=false
+   ```
+
+3. Using nodejs v16.x install the libs, start ganache-cli, and deploy the contracts to ganache
+
+   - > npm ci
+   - > npm run ganache
+   - > npm run deploy:ganache
+
+4. Set the tribute-ui env vars in the same `tribute-contracts/.env` file:
+
+   ```
+   ###### Docker Compose env vars ######
+
+   # It can be the same value you used for the Tribute DAO deployment.
+   REACT_APP_INFURA_PROJECT_ID_DEV=INFURA_API_KEY
+
+   # The address of the Multicall smart contract deployed to the Rinkeby network.
+   # Copy that from the tribute-contracts/logs/[network]-deploy.log
+   REACT_APP_MULTICALL_CONTRACT_ADDRESS=0x...
+
+   # The address of the DaoRegistry smart contract deployed to the Rinkeby network.
+   # Copy that from the tribute-contracts/logs/[network]-deploy.log
+   REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS=0x...
+
+   # The Ethereum Network node URL used by the Graph Node to listen to events.
+   ethereum=ganache:http://host.docker.internal:7545
+
+   # Enable Ganache network for Tribute UI
+   REACT_APP_ENVIRONMENT=local
+   REACT_APP_DEFAULT_CHAIN_NAME_LOCAL=GANACHE
+   ```
+
+5. Set the subgraph configs in the `subgraph-config.json` file
+
+   ```
+   ### tribute-contracts/subgraph/config/subgraph-config.json
+   [
+     {
+       "network": "ganache",
+       "daoFactoryAddress": "0x...", # Copy the DaoFactory contracts address from the deployment logs.
+       "daoFactoryStartBlock": blockNumber, # Copy the DaoFactory blockNumber from the deployment logs.
+       "GITHUB_USERNAME": "openlawteam", # do not change it
+       "SUBGRAPH_NAME": "tribute"  # do not change it
+     }
+   ]
+   ```
+
+6. Start all the services in the tribute-contracts/docker folder
+
+   - > docker-compose up
+   - Wait for the following output:
+     ```
+       trib-ui              | Compiled successfully!
+       trib-ui              |
+       trib-ui              | You can now view tribute-ui in the browser.
+       trib-ui              |
+       trib-ui              |   Local:            http://localhost:3000
+       trib-ui              |   On Your Network:  http://a.b.c.d:3000
+       trib-ui              |
+       trib-ui              | Note that the development build is not optimized.
+       trib-ui              | To create a production build, use npm run build.
+       trib-ui              |
+       trib-graph-node      | Sep 24 14:02:47.585 INFO Syncing 1 blocks from Ethereum., code: BlockIngestionStatus, blocks_needed: 1, blocks_behind: 1, latest_block_head: 13, current_block_head: 9349059, provider: ganache-rpc-0, component: BlockIngestor
+       ...
+     ```
+
+7. Using node v16.x deploy the subgraph
+
+   - > cd subgraph
+   - > npm install
+   - > npx ts-node subgraph-deployer.ts
+   - Wait for the following output:
+
+     ```
+     Deployed to http://localhost:8000/subgraphs/name/openlawteam/tribute/graphql
+
+     Subgraph endpoints:
+     Queries (HTTP):     http://localhost:8000/subgraphs/name/openlawteam/tribute
+     Subscriptions (WS): http://localhost:8001/subgraphs/name/openlawteam/tribute
+
+     👏 ### Done.
+     🎉 ### 1 Deployment(s) Successful!
+     ```
+
+   - Access your rinkeby DAO at http://localhost:3000
+   - Make sure you add the ganache network to your MetaMask
+     - Network: Ganache
+     - Port: 7545
+     - ChainId: 1337
+     - URL: http://localhost:7545

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,8 +21,8 @@
 
    # The contract which contains the previously deployed adapters and extensions,
    # so you don't have to deploy it again.
-   # Rinkeby: 
-   DAO_ARTIFACTS_CONTRACT_ADDR=0x...
+   # Rinkeby: 0xE5BE4f7CFf9E2A7Ece34909E68e30D71a7787d2A - contracts v2.3.2
+   DAO_ARTIFACTS_CONTRACT_ADDR=0xE5BE4f7CFf9E2A7Ece34909E68e30D71a7787d2A
 
    # You can set that to use the same address you have in the DAO_OWNER_ADDR
    COUPON_CREATOR_ADDR=0x...

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,143 @@
+### Launching a DAO
+
+1. Checkout tribute-contracts branch `release-v2.3.2`
+
+   - > cd tribute-contracts
+   - > git fetch origin release-v2.3.2
+   - > git checkout release-v2.3.2
+
+2. Set the env vars in the root of `tribute-contracts` project
+
+   ```
+   ###### Tribute Contracts env vars ######
+
+   # Set the name of your DAO.
+   DAO_NAME=My First DAO
+
+   # The public ethereum address that belongs to the Owner of the DAO,
+   # in this case, it is your public ethereum address on Rinkeby network.
+   # Make sure you have some ETH, otherwise the deployment will fail.
+   DAO_OWNER_ADDR=0x...
+
+   # The contract which contains the previously deployed adapters and extensions,
+   # so you don't have to deploy it again.
+   # Rinkeby: 
+   DAO_ARTIFACTS_CONTRACT_ADDR=0x...
+
+   # You can set that to use the same address you have in the DAO_OWNER_ADDR
+   COUPON_CREATOR_ADDR=0x...
+   KYC_COUPON_CREATOR_ADDR=0x...
+
+   # The name of the ERC20 token of your DAO.
+   ERC20_TOKEN_NAME=My First DAO Token
+
+   # The symbol of your ERC20 Token that will be used to control the
+   # DAO units that each member holds.
+   ERC20_TOKEN_SYMBOL=TDAO
+
+   # Number of decimals to display the token units in MM. We usually
+   # set 0 because the DAO units are managed in WEI, and to be able
+   # to see that in the MM wallet you need to remove the precision.
+   ERC20_TOKEN_DECIMALS=0
+
+   # The Ethereum Node URL to connect the Ethereum network. You can follow
+   # these steps to get your ProjectId/API Key from Infura:
+   # https://blog.infura.io/getting-started-with-infura-28e41844cc89/
+   # Or can use the default one from OpenLaw team, or set your own Infura/Alchemy API keys
+   ETH_NODE_URL=ws://rinkeby.openlaw.io:8546
+   #ETH_NODE_URL=wss://eth-rinkeby.ws.alchemyapi.io/v2/your-api-key
+   #ETH_NODE_URL=wss://rinkeby.infura.io/ws/v3/your-api-key
+
+   # The 12 word "secret recovery phrase" for the ethereum address
+   # referenced in DAO_OWNER_ADDR above. This can be found in your wallet.
+   # It will be used to create the HD wallet and sign transactions on your behalf.
+   TRUFFLE_MNEMONIC=...
+
+   ###### Subgraph env vars ######
+
+   # Set it to true if you want to deploy the subgraph to the TheGraph.com API.
+   # Usually we leave it disabled because we deploy to a local Graph Node
+   # created in docker/docker-compose.yml file.
+   REMOTE_GRAPH_NODE=false
+   ```
+
+3. Using nodejs v16.x install the libs & Deploy the contracts to rinkeby
+
+   - > npm ci && npm run deploy:rinkeby
+
+4. Set the tribute-ui env vars in the same `tribute-contracts/.env` file:
+
+   ```
+   ###### Docker Compose env vars ######
+
+   # Configure the UI to use the Rinkeby network for local development
+   REACT_APP_DEFAULT_CHAIN_NAME_LOCAL=RINKEBY
+
+   # It can be the same value you used for the Tribute DAO deployment.
+   REACT_APP_INFURA_PROJECT_ID_DEV=INFURA_API_KEY
+
+   # The address of the Multicall smart contract deployed to the Rinkeby network.
+   # Copy that from the tribute-contracts/logs/[network]-deploy.log
+   REACT_APP_MULTICALL_CONTRACT_ADDRESS=0x...
+
+   # The address of the DaoRegistry smart contract deployed to the Rinkeby network.
+   # Copy that from the tribute-contracts/logs/[network]-deploy.log
+   REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS=0x...
+
+   # The Ethereum Network node URL used by the Graph Node to listen to events.
+   ethereum=rinkeby:https://rinkeby.infura.io/v3/INFURA_API_KEY
+   ```
+
+5. Set the subgraph configs in the `subgraph-config.json` file
+
+   ```
+   ### tribute-contracts/subgraph/config/subgraph-config.json
+   [
+     {
+       "network": "rinkeby",
+       "daoFactoryAddress": "0x...", # Copy the DaoFactory contracts address from the deployment logs.
+       "daoFactoryStartBlock": blockNumber, # Copy the DaoFactory blockNumber from the deployment logs.
+       "GITHUB_USERNAME": "openlawteam", # do not change it
+       "SUBGRAPH_NAME": "tribute"  # do not change it
+     }
+   ]
+   ```
+
+6. Start all the services in the tribute-contracts/docker folder
+
+   - > docker-compose up
+   - Wait for the following output:
+     ```
+       trib-ui              | Compiled successfully!
+       trib-ui              |
+       trib-ui              | You can now view tribute-ui in the browser.
+       trib-ui              |
+       trib-ui              |   Local:            http://localhost:3000
+       trib-ui              |   On Your Network:  http://a.b.c.d:3000
+       trib-ui              |
+       trib-ui              | Note that the development build is not optimized.
+       trib-ui              | To create a production build, use npm run build.
+       trib-ui              |
+       trib-graph-node      | Sep 24 14:02:47.585 INFO Syncing 1 blocks from Ethereum., code: BlockIngestionStatus, blocks_needed: 1, blocks_behind: 1, latest_block_head: 9349060, current_block_head: 9349059, provider: rinkeby-rpc-0, component: BlockIngestor
+       ...
+     ```
+
+7. Using node v16.x deploy the subgraph
+
+   - > cd subgraph
+   - > npm install
+   - > npx ts-node subgraph-deployer.ts
+   - Wait for the following output:
+
+     ```
+     Deployed to http://localhost:8000/subgraphs/name/openlawteam/tribute/graphql
+
+     Subgraph endpoints:
+     Queries (HTTP):     http://localhost:8000/subgraphs/name/openlawteam/tribute
+     Subscriptions (WS): http://localhost:8001/subgraphs/name/openlawteam/tribute
+
+     👏 ### Done.
+     🎉 ### 1 Deployment(s) Successful!
+     ```
+
+   - Access your rinkeby DAO at http://localhost:3000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,120 @@
+# Compatible with Docker Engine v18.06.0+
+version: "3.7"
+services:
+
+  # Snapshot hub
+  trib-snapshot-hub:
+    image: openlaw/snapshot-hub:v5.0.1-erc712
+    container_name: trib-snapshot-hub
+    environment:
+      ENV: "local"
+      PORT: 8080
+      RELAYER_PK: "0xb80a5165a59af8ce566266fcd0e919e13ed4ecbd57ae952e73ae2cddc08b84c6"
+      ALCHEMY_API_URL: "http://rinkeby.openlaw.io:8545"
+      JAWSDB_URL: "postgres://snap:pwd123@trib-snapshot-db:5432/snapshot-db"
+      IGNORE_VOTE_END_CONSTRAINT: "true"
+      ALLOWED_DOMAINS: "http://localhost:3000"
+    depends_on:
+      - trib-snapshot-db
+    ports:
+      - 9090:8080
+
+  # Snapshot Postgres Database to store the Snapshot messages
+  trib-snapshot-db:
+    image: postgres:9.6
+    container_name: trib-snapshot-db
+    ports:
+      - "5432:5432"
+    command: ["postgres", "-p 5432"]
+    environment:
+      POSTGRES_USER: snap
+      POSTGRES_PASSWORD: pwd123
+      POSTGRES_DB: snapshot-db
+
+  # Graph node to host the Subgraph
+  trib-graph-node:
+    image: graphprotocol/graph-node:v0.24.1
+    container_name: trib-graph-node
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+      - "8020:8020"
+      - "8030:8030"
+      - "8040:8040"
+    depends_on:
+      - trib-graph-ipfs
+      - trib-graph-db
+    env_file:
+      - ../.env
+    environment:
+      node_id: "default"
+      node_role: "combined-node"
+      postgres_host: "trib-graph-db"
+      postgres_port: "5433"
+      postgres_user: "graph"
+      postgres_pass: "pwd123"
+      postgres_db: "graph-db"
+      ipfs: "http://trib-graph-ipfs:5001"
+      RUST_LOG: "info"
+      #GRAPH_LOG: "info"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # The IPFS instance to pin subgraph data
+  trib-graph-ipfs:
+    image: ipfs/go-ipfs:v0.9.1
+    container_name: trib-graph-ipfs
+    environment:
+      IPFS_PROFILE: "server"
+    ports:
+      - "4001:4001" # swarm
+      - "5001:5001" # api
+      - "8080:8080" # gateway (readonly)
+      - "8081:8081" # ws?
+    volumes:
+      - ./build/data/ipfs:/data/ipfs
+
+  # The Database to store the subgraph events
+  trib-graph-db:
+    image: postgres:9.6
+    container_name: trib-graph-db
+    ports:
+      - "5433:5433"
+    command: ["postgres", "-p 5433"]
+    environment:
+      POSTGRES_USER: graph
+      POSTGRES_PASSWORD: pwd123
+      POSTGRES_DB: graph-db
+
+  # The Tribute UI React App
+  trib-ui:
+    image: openlaw/tribute-ui:main-1eaa5a21
+    container_name: trib-ui
+    ports:
+      - "3000:3000"
+    command: ["npm", "start"]
+    depends_on:
+      - trib-snapshot-hub
+      - trib-graph-node
+    env_file:
+      - ../.env
+    environment:
+      # Do not change it.
+      # The url of the subgraph running locally in a container.
+      REACT_APP_GRAPH_API_URL: "http://localhost:8000/subgraphs/name/openlawteam/tribute"
+
+      # Do not change it.
+      # The url of snaphot-hub running locally in a container.
+      REACT_APP_SNAPSHOT_HUB_API_URL: "http://localhost:9090"
+
+      # Do not change it.
+      # The environment in which the app is being executed.
+      REACT_APP_ENVIRONMENT: ${REACT_APP_ENVIRONMENT}:"development"
+
+      # Do not change it.
+      # The unique name registered in Snapshot Hub under which proposals, votes, etc. will be stored.
+      REACT_APP_SNAPSHOT_SPACE: "tribute"
+
+networks:
+  default:
+    name: trib-network

--- a/website/docs/tutorial/dao/Configuration.md
+++ b/website/docs/tutorial/dao/Configuration.md
@@ -40,8 +40,8 @@ DAO_OWNER_ADDR=0x...
 
 # The contract which contains the previously deployed adapters and extensions,
 # so you don't have to deploy it again.
-# Rinkeby: 
-DAO_ARTIFACTS_CONTRACT_ADDR=
+# Rinkeby: 0xE5BE4f7CFf9E2A7Ece34909E68e30D71a7787d2A - contracts v2.3.2
+DAO_ARTIFACTS_CONTRACT_ADDR=0xE5BE4f7CFf9E2A7Ece34909E68e30D71a7787d2A
 
 # You can set that to use the same address you have in the DAO_OWNER_ADDR
 COUPON_CREATOR_ADDR=0x...

--- a/website/docs/tutorial/dao/Configuration.md
+++ b/website/docs/tutorial/dao/Configuration.md
@@ -12,7 +12,7 @@ title: Configuration
 ## Configuring the project
 
 :::warning
-Make sure you are on the branch [release-v1.0.6](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.0.6) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
+Make sure you are on the branch [release-v2.3.2](https://github.com/openlawteam/tribute-contracts/tree/release-v2.3.2) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
 :::
 
 ⚙️ Now that you have the `tribute-contracts` project prepared in your local environment, it is time to set up the DAO configs. These configs are a set of environment variables that will provide to the deployment script all the essential information to create the smart contracts in the correct Ethereum network. In this section we will be covering the deploying of the DAO using **[Rinkeby](https://rinkeby.etherscan.io/)** test network.
@@ -38,6 +38,11 @@ DAO_NAME=My First DAO
 # Make sure you have some ETH, otherwise the deployment will fail.
 DAO_OWNER_ADDR=0x...
 
+# The contract which contains the previously deployed adapters and extensions,
+# so you don't have to deploy it again.
+# Rinkeby: 
+DAO_ARTIFACTS_CONTRACT_ADDR=
+
 # You can set that to use the same address you have in the DAO_OWNER_ADDR
 COUPON_CREATOR_ADDR=0x...
 
@@ -57,9 +62,9 @@ ERC20_TOKEN_DECIMALS=0
 # these steps to get your ProjectId/API Key from Infura:
 # https://blog.infura.io/getting-started-with-infura-28e41844cc89/
 # Or can use the default one from OpenLaw team, or set your own Infura/Alchemy API keys
+ETH_NODE_URL=ws://rinkeby.openlaw.io:8546
 #ETH_NODE_URL=wss://eth-rinkeby.ws.alchemyapi.io/v2/your-api-key
-# Replace the "your-api-key" with your infura key
-ETH_NODE_URL=wss://rinkeby.infura.io/ws/v3/your-api-key
+#ETH_NODE_URL=wss://rinkeby.infura.io/ws/v3/your-api-key
 
 # The 12 word "secret recovery phrase" for the ethereum address
 # referenced in DAO_OWNER_ADDR above. This can be found in your wallet.

--- a/website/docs/tutorial/dao/Deployment.md
+++ b/website/docs/tutorial/dao/Deployment.md
@@ -37,24 +37,23 @@ At the end of the deployment process you should see the following output:
 
 ```bash
 ...
-************************
+************************************************
+DaoOwner: 0x...
 DaoRegistry: 0x...
-BankExtension: 0x...
-NFTExtension: 0x...
-ERC20Extension: 0x...
-************************
+NFTCollectionFactory: 0x...
+BankFactory: 0x...
+...
+************************************************
+
+Deployed contracts: ~/Development/tribute-contracts/build/contracts-rinkeby-YYYY-MM-DDThh:mm:ss.ZZZ.json
+
+Deployment completed at: YYYY-MM-DDThh:mm:ss.ZZZ
 
 - Saving migration to chain.
    > Saving migration to chain.
    > Saving artifacts
    -------------------------------------
-   > Total cost:          0.51462506 ETH
-
-
-Summary
-=======
-> Total deployments:   34
-> Final cost:          0.51610942 ETH
+   > Total cost:     0.062332692391045646 ETH
 ```
 
 ⚡️ Awesome!! You have deployed your DAO to the **[Rinkeby](https://rinkeby.etherscan.io/)** test network, and now it is time to interact with it using our dApp called **[Tribute UI](https://github.com/openlawteam/tribute-ui)**. Checkout the next section to dive into that.

--- a/website/docs/tutorial/dao/Deployment.md
+++ b/website/docs/tutorial/dao/Deployment.md
@@ -14,7 +14,7 @@ title: Deployment
 ## Deploying your DAO
 
 :::warning
-Make sure you are on the branch [release-v1.0.6](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.0.6) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
+Make sure you are on the branch [release-v2.3.2](https://github.com/openlawteam/tribute-contracts/tree/release-v2.3.2) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
 :::
 
 ### Command line

--- a/website/docs/tutorial/dao/Installation.md
+++ b/website/docs/tutorial/dao/Installation.md
@@ -15,7 +15,7 @@ sidebar_position: 2
 ## Creating the project
 
 :::warning
-Make sure you are on the branch [release-v1.0.6](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.0.6) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
+Make sure you are on the branch [release-v2.3.2](https://github.com/openlawteam/tribute-contracts/tree/release-v2.3.2) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
 :::
 
 The easiest way to start with TributeDAO Framework is to use the command line tool to clone the Github repository, and install all the project dependencies.
@@ -26,11 +26,11 @@ Clone and access the _tribute-contracts_ Github repo:
 git clone https://github.com/openlawteam/tribute-contracts.git && cd tribute-contracts
 ```
 
-Fetch and checkout the branch `release-v1.0.6`:
+Fetch and checkout the branch `release-v2.3.2`:
 
-> git fetch origin release-v1.0.6
+> git fetch origin release-v2.3.2
 
-> git checkout release-v1.0.6
+> git checkout release-v2.3.2
 
 Install all the project dependencies and deploy the smart contracts:
 

--- a/website/docs/tutorial/dao/TributeUI.md
+++ b/website/docs/tutorial/dao/TributeUI.md
@@ -14,7 +14,7 @@ title: Tribute UI
 ## Configuring the dApp
 
 :::warning
-Make sure you are on the branch [release-v1.0.6](https://github.com/openlawteam/tribute-contracts/releases/tag/v1.0.6) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
+Make sure you are on the branch [release-v2.3.2](https://github.com/openlawteam/tribute-contracts/tree/release-v2.3.2) which is the version that contains the contracts integrated with [TributeUI](https://github.com/openlawteam/tribute-ui).
 :::
 
 In order to run the dApp we will be using `docker-compose`, which will help us to spin up all the services required by the dApp.


### PR DESCRIPTION
## Proposed Changes

- [x] Using the latest release of tribute contracts to deploy a demo DAO
- [x] Enabled the DAO Artifacts to speed up the deployment and save gas 
- [x] Update required env vars
- [ ] Update the tribute-ui docker image (the one that is integrated with v2.3.2+)
