### PR TITLE
fix: isActiveMember, requestStep, and voting power validation

### DIFF
--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -376,7 +376,7 @@ contract OffchainVotingContract is
         vote.resultRoot = resultRoot;
         vote.reporter = memberAddr;
         vote.isChallenged = false;
-        vote.nbMembers = dao.getNbMembers();
+        vote.nbMembers = membersCount;
 
         emit VoteResultSubmitted(
             address(dao),

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -63,11 +63,11 @@ contract OffchainVotingContract is
         uint256 nbNo;
         uint64 startingTime;
         uint64 gracePeriodStartingTime;
-        uint64 fallbackVotesCount;
         bool isChallenged;
         bool forceFailed;
         uint256 nbMembers;
         uint256 stepRequested;
+        uint256 fallbackVotesCount;
         mapping(address => bool) fallbackVotes;
     }
 

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -61,13 +61,14 @@ contract OffchainVotingContract is
         bytes32 resultRoot;
         uint256 nbYes;
         uint256 nbNo;
-        uint256 startingTime;
-        uint256 gracePeriodStartingTime;
+        uint64 startingTime;
+        uint64 gracePeriodStartingTime;
+        uint64 fallbackVotesCount;
         bool isChallenged;
-        uint256 stepRequested;
         bool forceFailed;
+        uint256 nbMembers;
+        uint256 stepRequested;
         mapping(address => bool) fallbackVotes;
-        uint256 fallbackVotesCount;
     }
 
     struct VotingDetails {
@@ -368,13 +369,14 @@ contract OffchainVotingContract is
             // check whether the new result changes the outcome
             vote.nbNo > vote.nbYes != result.nbNo > result.nbYes
         ) {
-            vote.gracePeriodStartingTime = block.timestamp;
+            vote.gracePeriodStartingTime = uint64(block.timestamp);
         }
         vote.nbNo = result.nbNo;
         vote.nbYes = result.nbYes;
         vote.resultRoot = resultRoot;
         vote.reporter = memberAddr;
         vote.isChallenged = false;
+        vote.nbMembers = dao.getNbMembers();
 
         emit VoteResultSubmitted(
             address(dao),
@@ -395,6 +397,7 @@ contract OffchainVotingContract is
         address memberAddr = dao.getAddressIfDelegated(msg.sender);
         require(isActiveMember(dao, memberAddr), "not active member");
         Voting storage vote = votes[address(dao)][proposalId];
+        require(index < vote.nbMembers, "index out of bound");
         uint256 currentFlag = retrievedStepsFlags[vote.resultRoot][index / 256];
         require(
             DaoHelper.getFlag(currentFlag, index % 256) == false,
@@ -413,7 +416,7 @@ contract OffchainVotingContract is
             "should be grace period"
         );
         vote.stepRequested = index;
-        vote.gracePeriodStartingTime = block.timestamp;
+        vote.gracePeriodStartingTime = uint64(block.timestamp);
     }
 
     /*
@@ -451,7 +454,7 @@ contract OffchainVotingContract is
         _verifyNode(dao, adapterAddress, node, vote.resultRoot);
 
         vote.stepRequested = 0;
-        vote.gracePeriodStartingTime = block.timestamp;
+        vote.gracePeriodStartingTime = uint64(block.timestamp);
     }
 
     // slither-disable-next-line reentrancy-benign
@@ -471,7 +474,7 @@ contract OffchainVotingContract is
         require(blockNumber <= block.number, "snapshot block in future");
         require(blockNumber > 0, "block number cannot be 0");
 
-        votes[address(dao)][proposalId].startingTime = block.timestamp;
+        votes[address(dao)][proposalId].startingTime = uint64(block.timestamp);
         votes[address(dao)][proposalId].snapshot = blockNumber;
 
         require(

--- a/contracts/core/DaoRegistry.sol
+++ b/contracts/core/DaoRegistry.sol
@@ -558,7 +558,7 @@ contract DaoRegistry is MemberGuard, AdapterGuard {
 
         require(
             proposal.adapterAddress == msg.sender,
-            "only the adapter that submitted the proposal can set its flag"
+            "invalid adapter try to set flag"
         );
 
         require(!DaoHelper.getFlag(flags, uint8(flag)), "flag already set");
@@ -720,10 +720,7 @@ contract DaoRegistry is MemberGuard, AdapterGuard {
         view
         returns (address)
     {
-        require(
-            blockNumber < block.number,
-            "Uni::getPriorDelegateKey: not yet determined"
-        );
+        require(blockNumber < block.number, "Uni::getPriorDelegateKey: NYD");
 
         uint32 nCheckpoints = numCheckpoints[memberAddr];
         if (nCheckpoints == 0) {

--- a/contracts/guards/MemberGuard.sol
+++ b/contracts/guards/MemberGuard.sol
@@ -56,10 +56,12 @@ abstract contract MemberGuard {
         if (bankAddress != address(0x0)) {
             address memberAddr = dao.getAddressIfDelegated(_addr);
             return
+                dao.isMember(_addr) &&
                 BankExtension(bankAddress).balanceOf(
                     memberAddr,
                     DaoHelper.UNITS
-                ) > 0;
+                ) >
+                0;
         }
 
         return dao.isMember(_addr);

--- a/contracts/helpers/OffchainVotingHelper.sol
+++ b/contracts/helpers/OffchainVotingHelper.sol
@@ -166,12 +166,14 @@ contract OffchainVotingHelperContract {
 
         // If the weight is 0, the member has no permission to vote
         if (
+            node.choice != 0 &&
             GovernanceHelper.getVotingWeight(
                 dao,
                 memberAddr, // always check the weight of the member, not the delegate
                 node.proposalId,
                 blockNumber
-            ) == 0
+            ) ==
+            0
         ) {
             return BadNodeError.VOTE_NOT_ALLOWED;
         }

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -296,6 +296,7 @@ describe("Adapter - Managing", () => {
     const daoRegistryAdapterAddress = await dao.getAdapterAddress(
       sha3("daoRegistry")
     );
+
     const daoRegistryAdapter = await DaoRegistryAdapterContract.at(
       daoRegistryAdapterAddress
     );
@@ -311,10 +312,18 @@ describe("Adapter - Managing", () => {
       gasPrice: toBN("0"),
     });
 
-    // The same member attempts to vote again
     await expectRevert(
       voting.submitVote(dao.address, proposalId, 1, {
         from: daoOwner,
+        gasPrice: toBN("0"),
+      }),
+      "onlyMember"
+    );
+
+    // The same member attempts to vote again
+    await expectRevert(
+      voting.submitVote(dao.address, proposalId, 1, {
+        from: delegateKey,
         gasPrice: toBN("0"),
       }),
       "member has already voted"


### PR DESCRIPTION
## Proposed Change

- fix isActiveMember to check that the address is an actual member. 
- fix request step to check that index is smaller than nbMembers to avoid requesting a non existing step
- fix the voting power validation, only vote results with an actual choice (1/2) should be validated
- feat: added the `nbMembers` attribute to the vote result to be able to verify if a requested step actually exists
- fix test: a member that delegated the voting power should not be allowed to vote, and will receive the `onlyMember` error because one needs to use the delegate key.