### PR TITLE
fix: kyc onboard with delegate key + erc1155 token transfers

### DIFF
--- a/contracts/adapters/DaoRegistryAdapter.sol
+++ b/contracts/adapters/DaoRegistryAdapter.sol
@@ -43,6 +43,9 @@ contract DaoRegistryAdapterContract is MemberGuard, AdapterGuard {
         reentrancyGuard(dao)
         onlyMember(dao)
     {
-        dao.updateDelegateKey(msg.sender, delegateKey);
+        dao.updateDelegateKey(
+            DaoHelper.msgSender(dao, msg.sender),
+            delegateKey
+        );
     }
 }

--- a/contracts/adapters/KycOnboarding.sol
+++ b/contracts/adapters/KycOnboarding.sol
@@ -241,11 +241,9 @@ contract KycOnboardingContract is
         uint256 amount,
         bytes memory signature
     ) internal reimbursable(dao) {
-        require(
-            !isDelegatedMemberAddr(dao, kycedMember),
-            "call with your delegate key"
-        );
-        require(!isActiveMember(dao, kycedMember), "already member");
+        address delegateKey = dao.getCurrentDelegateKey(kycedMember);
+
+        require(!isActiveMember(dao, delegateKey), "already member");
         uint256 maxMembers = dao.getConfiguration(
             _configKey(tokenAddr, MaxMembers)
         );

--- a/contracts/adapters/KycOnboarding.sol
+++ b/contracts/adapters/KycOnboarding.sol
@@ -241,9 +241,10 @@ contract KycOnboardingContract is
         uint256 amount,
         bytes memory signature
     ) internal reimbursable(dao) {
-        address delegateKey = dao.getCurrentDelegateKey(kycedMember);
-
-        require(!isActiveMember(dao, delegateKey), "already member");
+        require(
+            !isActiveMember(dao, dao.getCurrentDelegateKey(kycedMember)),
+            "already member"
+        );
         uint256 maxMembers = dao.getConfiguration(
             _configKey(tokenAddr, MaxMembers)
         );

--- a/contracts/adapters/KycOnboarding.sol
+++ b/contracts/adapters/KycOnboarding.sol
@@ -241,6 +241,10 @@ contract KycOnboardingContract is
         uint256 amount,
         bytes memory signature
     ) internal reimbursable(dao) {
+        require(
+            !isDelegatedMemberAddr(dao, kycedMember),
+            "call with your delegate key"
+        );
         require(!isActiveMember(dao, kycedMember), "already member");
         uint256 maxMembers = dao.getConfiguration(
             _configKey(tokenAddr, MaxMembers)

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -69,7 +69,7 @@ contract RagequitContract is IRagequit, AdapterGuard {
         // Checks if the are enough units and/or loot to burn
         require(unitsToBurn + lootToBurn > 0, "insufficient units/loot");
         // Gets the delegated address, otherwise returns the sender address.
-        address memberAddr = dao.getAddressIfDelegated(msg.sender);
+        address memberAddr = DaoHelper.msgSender(dao, msg.sender);
 
         // Instantiates the Bank extension to handle the internal balance checks and transfers.
         BankExtension bank = BankExtension(

--- a/contracts/adapters/voting/Voting.sol
+++ b/contracts/adapters/voting/Voting.sol
@@ -148,7 +148,7 @@ contract VotingContract is IVoting, MemberGuard, AdapterGuard, Reimbursable {
             "vote has already ended"
         );
 
-        address memberAddr = dao.getAddressIfDelegated(msg.sender);
+        address memberAddr = DaoHelper.msgSender(dao, msg.sender);
 
         require(vote.votes[memberAddr] == 0, "member has already voted");
         uint256 votingWeight = GovernanceHelper.getVotingWeight(

--- a/contracts/extensions/erc1155/ERC1155TokenExtension.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtension.sol
@@ -336,6 +336,7 @@ contract ERC1155TokenExtension is IExtension, IERC1155Receiver {
         //slither-disable-next-line unused-return
         _ownership[getNFTId(nftAddr, nftTokenId)].add(owner);
         // Keep track of the collected assets addresses
+        //slither-disable-next-line unused-return
         _nftAddresses.add(nftAddr);
         // Track the actual owner per Token Id and amount
         uint256 currentAmount = _nftTracker[owner][nftAddr][nftTokenId];

--- a/contracts/extensions/erc1155/ERC1155TokenExtension.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtension.sol
@@ -197,18 +197,18 @@ contract ERC1155TokenExtension is MemberGuard, IExtension, IERC1155Receiver {
     ) external hasExtensionAccess(this, AclFlag.INTERNAL_TRANSFER) {
         require(
             isActiveMember(dao, fromOwner),
-            "erc1155Ext::fromOwner is not a member"
+            "erc1155Ext::fromOwner not member"
         );
         require(
             isActiveMember(dao, toOwner),
-            "erc1155Ext::toOwner is not a member"
+            "erc1155Ext::toOwner not member"
         );
 
         // Checks if there token amount is valid and has enough funds
         uint256 tokenAmount = _getTokenAmount(fromOwner, nftAddr, nftTokenId);
         require(
             amount > 0 && tokenAmount >= amount,
-            "erc1155Ext::insufficient funds or invalid amount"
+            "erc1155Ext::invalid amount"
         );
 
         // Checks if the extension holds the NFT

--- a/contracts/extensions/erc1155/ERC1155TokenExtension.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtension.sol
@@ -152,9 +152,11 @@ contract ERC1155TokenExtension is IExtension, IERC1155Receiver {
             delete _nftTracker[newOwner][nftAddr][nftTokenId];
             //slither-disable-next-line unused-return
             _ownership[getNFTId(nftAddr, nftTokenId)].remove(newOwner);
+            //slither-disable-next-line unused-return
             _nfts[nftAddr].remove(nftTokenId);
             // If there are 0 tokenIds for the NFT address, remove the NFT from the collection
             if (_nfts[nftAddr].length() == 0) {
+                //slither-disable-next-line unused-return
                 _nftAddresses.remove(nftAddr);
                 delete _nfts[nftAddr];
             }
@@ -328,8 +330,10 @@ contract ERC1155TokenExtension is IExtension, IERC1155Receiver {
         uint256 amount
     ) private {
         // Save the asset address and tokenId
+        //slither-disable-next-line unused-return
         _nfts[nftAddr].add(nftTokenId);
         // Track the owner by nftAddr+tokenId
+        //slither-disable-next-line unused-return
         _ownership[getNFTId(nftAddr, nftTokenId)].add(owner);
         // Keep track of the collected assets addresses
         _nftAddresses.add(nftAddr);

--- a/contracts/extensions/erc1155/ERC1155TokenExtension.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtension.sol
@@ -33,7 +33,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-contract ERC1155TokenExtension is MemberGuard, IExtension, IERC1155Receiver {
+contract ERC1155TokenExtension is IExtension, IERC1155Receiver {
     using Address for address payable;
     //LIBRARIES
     using EnumerableSet for EnumerableSet.UintSet;
@@ -195,15 +195,6 @@ contract ERC1155TokenExtension is MemberGuard, IExtension, IERC1155Receiver {
         uint256 nftTokenId,
         uint256 amount
     ) external hasExtensionAccess(this, AclFlag.INTERNAL_TRANSFER) {
-        require(
-            isActiveMember(dao, fromOwner),
-            "erc1155Ext::fromOwner not member"
-        );
-        require(
-            isActiveMember(dao, toOwner),
-            "erc1155Ext::toOwner not member"
-        );
-
         // Checks if there token amount is valid and has enough funds
         uint256 tokenAmount = _getTokenAmount(fromOwner, nftAddr, nftTokenId);
         require(

--- a/contracts/guards/MemberGuard.sol
+++ b/contracts/guards/MemberGuard.sol
@@ -47,6 +47,16 @@ abstract contract MemberGuard {
         require(isActiveMember(dao, _addr), "onlyMember");
     }
 
+    function isDelegatedMemberAddr(DaoRegistry dao, address _addr)
+        public
+        view
+        returns (bool)
+    {
+        address delegateKey = dao.getCurrentDelegateKey(_addr);
+
+        return !dao.isMember(_addr) && dao.isMember(delegateKey);
+    }
+
     function isActiveMember(DaoRegistry dao, address _addr)
         public
         view

--- a/contracts/guards/MemberGuard.sol
+++ b/contracts/guards/MemberGuard.sol
@@ -54,7 +54,7 @@ abstract contract MemberGuard {
     {
         address bankAddress = dao.extensions(DaoHelper.BANK);
         if (bankAddress != address(0x0)) {
-            address memberAddr = dao.getAddressIfDelegated(_addr);
+            address memberAddr = DaoHelper.msgSender(dao, _addr);
             return
                 dao.isMember(_addr) &&
                 BankExtension(bankAddress).balanceOf(

--- a/contracts/guards/MemberGuard.sol
+++ b/contracts/guards/MemberGuard.sol
@@ -52,9 +52,12 @@ abstract contract MemberGuard {
         view
         returns (bool)
     {
-        address delegateKey = dao.getCurrentDelegateKey(_addr);
-
-        return !dao.isMember(_addr) && dao.isMember(delegateKey);
+        //if the address points to another member address, then it is using the delegate key
+        if (dao.getAddressIfDelegated(_addr) != _addr) {
+            return false;
+        }
+        //if getAddressIfDelegated(addr) == addr, then we need to check if the address has a delegate key linked to it.
+        return dao.getCurrentDelegateKey(_addr) != _addr;
     }
 
     function isActiveMember(DaoRegistry dao, address _addr)

--- a/contracts/guards/MemberGuard.sol
+++ b/contracts/guards/MemberGuard.sol
@@ -47,19 +47,6 @@ abstract contract MemberGuard {
         require(isActiveMember(dao, _addr), "onlyMember");
     }
 
-    function isDelegatedMemberAddr(DaoRegistry dao, address _addr)
-        public
-        view
-        returns (bool)
-    {
-        //if the address points to another member address, then it is using the delegate key
-        if (dao.getAddressIfDelegated(_addr) != _addr) {
-            return false;
-        }
-        //if getAddressIfDelegated(addr) == addr, then we need to check if the address has a delegate key linked to it.
-        return dao.getCurrentDelegateKey(_addr) != _addr;
-    }
-
     function isActiveMember(DaoRegistry dao, address _addr)
         public
         view

--- a/contracts/helpers/DaoHelper.sol
+++ b/contracts/helpers/DaoHelper.sol
@@ -112,6 +112,22 @@ library DaoHelper {
             bank.balanceOf(member, LOCKED_LOOT);
     }
 
+    function msgSender(DaoRegistry dao, address addr)
+        internal
+        view
+        returns (address)
+    {
+        address memberAddress = dao.getAddressIfDelegated(addr);
+        address delegatedAddress = dao.getCurrentDelegateKey(addr);
+
+        require(
+            memberAddress == delegatedAddress || delegatedAddress == addr,
+            "call with your delegate key"
+        );
+
+        return memberAddress;
+    }
+
     /**
      * @notice calculates the total number of units.
      */

--- a/contracts/test/ERC1155TestAdapter.sol
+++ b/contracts/test/ERC1155TestAdapter.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import "../core/DaoRegistry.sol";
 import "../extensions/erc1155/ERC1155TokenExtension.sol";
 import "../guards/AdapterGuard.sol";
-import "./interfaces/IConfiguration.sol";
 import "../adapters/interfaces/IVoting.sol";
 import "../helpers/DaoHelper.sol";
 
@@ -32,20 +31,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-contract ERC1155AdapterContract is AdapterGuard {
+contract ERC1155TestAdapterContract is AdapterGuard {
     /**
      * @notice Internally transfers the NFT from one owner to a new owner as long as both are active members.
      * @notice Reverts if the addresses of the owners are not members.
      * @notice Reverts if the fromOwner does not hold the NFT.
      * @param dao The DAO address.
-     * @param toOwner The new owner address of the NFT.
      * @param nftAddr The NFT smart contract address.
      * @param nftTokenId The NFT token id.
      * @param amount of the nftTokenId.
      */
     function internalTransfer(
         DaoRegistry dao,
-        address toOwner,
         address nftAddr,
         uint256 nftTokenId,
         uint256 amount
@@ -54,8 +51,8 @@ contract ERC1155AdapterContract is AdapterGuard {
             dao.getExtensionAddress(DaoHelper.ERC1155_EXT)
         );
         erc1155.internalTransfer(
+            DaoHelper.GUILD,
             DaoHelper.msgSender(dao, msg.sender),
-            toOwner,
             nftAddr,
             nftTokenId,
             amount

--- a/migrations/configs/test.config.ts
+++ b/migrations/configs/test.config.ts
@@ -1,11 +1,32 @@
 import {
   contracts as defaultContracts,
   ContractConfig,
+  ContractType
 } from "./contracts.config";
+import { extensionsIdsMap } from "../../utils/dao-ids-util";
+
+import {erc1155ExtensionAclFlagsMap} from "../../utils/access-control-util";
 
 const disabled: Array<string> = [];
 
-export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {
+const testContracts = [{
+  id: "erc1155-test",
+  name: "ERC1155TestAdapter",
+  alias: "erc1155TestAdapter",
+  path: "../../contracts/test/ERC1155TestAdapterContract",
+  enabled: true,
+  version: "1.0.0",
+  type: ContractType.Adapter,
+  acls: {
+    dao: [],
+    extensions: {[extensionsIdsMap.ERC1155_EXT]: [
+      erc1155ExtensionAclFlagsMap.INTERNAL_TRANSFER,
+    ]},
+  },
+  deploymentArgs: [],
+}];
+
+export const contracts: Array<ContractConfig> = defaultContracts.concat(testContracts).map((c) => {
   if (disabled.find((e) => e === c.name)) {
     return { ...c, enabled: false };
   }

--- a/test/adapters/kyc-onboarding.test.js
+++ b/test/adapters/kyc-onboarding.test.js
@@ -327,15 +327,6 @@ describe("Adapter - KYC Onboarding", () => {
 
     await expectRevert(
       onboarding.onboardEth(dao.address, applicant, signature, {
-        from: applicant,
-        value: ethAmount,
-        gasPrice: toBN("0"),
-      }),
-      "already member"
-    );
-
-    await expectRevert(
-      onboarding.onboardEth(dao.address, applicant, signature, {
         from: delegateKey,
         value: ethAmount,
         gasPrice: toBN("0"),

--- a/test/adapters/kyc-onboarding.test.js
+++ b/test/adapters/kyc-onboarding.test.js
@@ -331,7 +331,16 @@ describe("Adapter - KYC Onboarding", () => {
         value: ethAmount,
         gasPrice: toBN("0"),
       }),
-      "call with your delegate key"
+      "already member"
+    );
+
+    await expectRevert(
+      onboarding.onboardEth(dao.address, applicant, signature, {
+        from: delegateKey,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }),
+      "already member"
     );
   });
 

--- a/test/adapters/kyc-onboarding.test.js
+++ b/test/adapters/kyc-onboarding.test.js
@@ -271,6 +271,70 @@ describe("Adapter - KYC Onboarding", () => {
     expect(nonMemberAccountIsActiveMember).equal(false);
   });
 
+  it("should not be possible to join the same member after he delegates his membership to another address", async () => {
+    const applicant = accounts[2];
+    const delegateKey = accounts[3];
+
+    const dao = this.dao;
+    const bank = this.extensions.bankExt;
+    const onboarding = this.adapters.kycOnboarding;
+    const daoRegistryAdapter = this.adapters.daoRegistryAdapter;
+
+    const myAccountInitialBalance = await web3.eth.getBalance(applicant);
+    // remaining amount to test sending back to proposer
+    const ethAmount = unitPrice.mul(toBN(3)).add(remaining);
+
+    const signerUtil = SigUtilSigner(signer.privKey);
+
+    const couponData = {
+      type: "coupon-kyc",
+      kycedMember: applicant,
+    };
+
+    let jsHash = getMessageERC712Hash(
+      couponData,
+      dao.address,
+      onboarding.address,
+      1
+    );
+    let solHash = await onboarding.hashCouponMessage(dao.address, couponData);
+    expect(jsHash).equal(solHash);
+
+    const signature = signerUtil(
+      couponData,
+      dao.address,
+      onboarding.address,
+      1
+    );
+
+    await onboarding.onboardEth(dao.address, applicant, signature, {
+      from: applicant,
+      value: ethAmount,
+      gasPrice: toBN("0"),
+    });
+
+    // test return of remaining amount in excess of multiple of unitsPerChunk
+    const myAccountBalance = await web3.eth.getBalance(applicant);
+    // daoOwner did not receive remaining amount in excess of multiple of unitsPerChunk
+    expect(
+      toBN(myAccountInitialBalance).sub(ethAmount).add(remaining).toString()
+    ).equal(myAccountBalance.toString());
+
+    await daoRegistryAdapter.updateDelegateKey(dao.address, delegateKey, {
+      from: applicant,
+      gasPrice: toBN("0"),
+    });
+
+    await expectRevert(
+      onboarding.onboardEth(dao.address, applicant, signature, {
+        from: applicant,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }),
+      "call with your delegate key"
+    );
+  });
+
   it("should not be possible to have more than the maximum number of units", async () => {
     const applicant = accounts[2];
     const dao = this.dao;

--- a/test/adapters/managing.test.js
+++ b/test/adapters/managing.test.js
@@ -317,7 +317,7 @@ describe("Adapter - Managing", () => {
         from: daoOwner,
         gasPrice: toBN("0"),
       }),
-      "onlyMember"
+      "call with your delegate key"
     );
 
     // The same member attempts to vote again

--- a/test/extensions/erc1155.test.js
+++ b/test/extensions/erc1155.test.js
@@ -261,7 +261,13 @@ describe("Extension - ERC1155", () => {
       { from: nftOwner }
     );
 
-    //TODO: check that transfer went well
+    const nonMemberBalance = await erc1155Ext.getNFTIdAmount(
+      nonMember,
+      erc1155TestToken.address,
+      1
+    );
+
+    expect(nonMemberBalance.toString()).equal("1");
   });
 
   it("should not be possible to transfer the NFT when you are not the owner", async () => {

--- a/test/extensions/erc1155.test.js
+++ b/test/extensions/erc1155.test.js
@@ -252,7 +252,15 @@ describe("Extension - ERC1155", () => {
     expect(await isMember(bank, nftOwner)).equal(true);
     //internalTransfer should revert, because nonMember is not a member
 
-    erc1155Adapter.internalTransfer(
+    await this.adapters.erc1155TestAdapter.internalTransfer(
+      this.dao.address,
+      erc1155TestToken.address,
+      id, //tokenId
+      2, //amount
+      { from: nftOwner }
+    );
+
+    await erc1155Adapter.internalTransfer(
       this.dao.address,
       nonMember,
       erc1155TestToken.address,
@@ -261,13 +269,20 @@ describe("Extension - ERC1155", () => {
       { from: nftOwner }
     );
 
-    const nonMemberBalance = await erc1155Ext.getNFTIdAmount(
+    const nonMemberBalance = await erc1155TokenExtension.getNFTIdAmount(
       nonMember,
       erc1155TestToken.address,
       1
     );
 
+    const nftOwnerBalance = await erc1155TokenExtension.getNFTIdAmount(
+      nftOwner,
+      erc1155TestToken.address,
+      1
+    );
+
     expect(nonMemberBalance.toString()).equal("1");
+    expect(nftOwnerBalance.toString()).equal("1");
   });
 
   it("should not be possible to transfer the NFT when you are not the owner", async () => {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -94,7 +94,7 @@ module.exports = {
         // See the solidity docs for advice about optimization and evmVersion
         optimizer: {
           enabled: !(process.env.DISABLE_SOLC_OPTIMIZER === "true"),
-          runs: 10000,
+          runs: 200,
         },
         //  evmVersion: "byzantium"
       },

--- a/utils/oz-util.js
+++ b/utils/oz-util.js
@@ -32,6 +32,8 @@ const {
   provider,
 } = require("@openzeppelin/test-environment");
 
+const { entryDao } = require("./access-control-util");
+
 const {
   unitPrice,
   numberOfUnits,
@@ -45,11 +47,12 @@ const {
 
 const { expect } = require("chai");
 const { expectRevert } = require("@openzeppelin/test-helpers");
-const { deployDao } = require("./deployment-util.js");
+const { deployDao, configureExtensionAccess } = require("./deployment-util.js");
 const {
   contracts: allContractConfigs,
 } = require("../migrations/configs/test.config");
 const { ContractType } = require("../migrations/configs/contracts.config");
+const { sha3 } = require("web3-utils");
 
 const deployFunction = async (contractInterface, args, from) => {
   if (!contractInterface) throw Error("undefined contract interface");


### PR DESCRIPTION
## Proposed Changes

- If a member has delegate the voting power, the onboard process need to verify if that member has a delegate and prevent him from joining again. 
- The internal transfers in the ERC1155 extension should not verify if it is an active member or not