### PR TITLE
fix: impersonation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
-.env.test
+.env*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/contracts/adapters/BankAdapter.sol
+++ b/contracts/adapters/BankAdapter.sol
@@ -78,6 +78,7 @@ contract BankAdapterContract is DaoConstants, AdapterGuard {
         // We do not need to check if the token is supported by the bank,
         // because if it is not, the balance will always be zero.
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+        require(bank.dao() == dao, "wrong dao");
         bank.updateToken(token);
     }
 }

--- a/contracts/adapters/CouponOnboarding.sol
+++ b/contracts/adapters/CouponOnboarding.sol
@@ -128,7 +128,7 @@ contract CouponOnboardingContract is
         );
 
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
-
+        require(bank.dao() == dao, "wrong dao");
         bank.addToBalance(authorizedMember, tokenAddrToMint, amount);
         // address needs to be added to the members mappings
         potentialNewMember(authorizedMember, dao, bank);

--- a/contracts/adapters/Distribute.sol
+++ b/contracts/adapters/Distribute.sol
@@ -217,6 +217,7 @@ contract DistributeContract is
             ongoingDistributions[address(dao)] = proposalId;
 
             BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+            require(bank.dao() == dao, "wrong dao");
             uint256 balance = bank.balanceOf(GUILD, distribution.token);
             require(
                 balance - distribution.amount >= 0,

--- a/contracts/adapters/Financing.sol
+++ b/contracts/adapters/Financing.sol
@@ -79,6 +79,7 @@ contract FinancingContract is
     ) external override reentrancyGuard(dao) {
         require(amount > 0, "invalid requested amount");
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+        require(bank.dao() == dao, "wrong dao");
         require(bank.isTokenAllowed(token), "token not allowed");
         require(
             isNotReservedAddress(applicant),

--- a/contracts/adapters/GuildKick.sol
+++ b/contracts/adapters/GuildKick.sol
@@ -104,6 +104,7 @@ contract GuildKickContract is IGuildKick, MemberGuard, AdapterGuard {
         dao.submitProposal(proposalId);
 
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+        require(bank.dao() == dao, "wrong dao");
         // Gets the number of units of the member
         uint256 unitsToBurn = bank.balanceOf(memberToKick, UNITS);
 

--- a/contracts/adapters/KycOnboarding.sol
+++ b/contracts/adapters/KycOnboarding.sol
@@ -204,6 +204,7 @@ contract KycOnboardingContract is
         OnboardingDetails memory details = _checkData(dao);
 
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+        require(bank.dao() == dao, "wrong dao");
         potentialNewMember(kycedMember, dao, bank);
         totalUnits[dao] += details.unitsRequested;
         address payable multisigAddress = payable(

--- a/contracts/adapters/NFTAdapter.sol
+++ b/contracts/adapters/NFTAdapter.sol
@@ -54,6 +54,7 @@ contract NFTAdapterContract is DaoConstants, MemberGuard, AdapterGuard {
         uint256 nftTokenId
     ) external reentrancyGuard(dao) {
         NFTExtension nft = NFTExtension(dao.getExtensionAddress(NFT));
+        require(nft.dao() == dao, "wrong dao");
         nft.collect(nftAddr, nftTokenId);
     }
 }

--- a/contracts/adapters/Onboarding.sol
+++ b/contracts/adapters/Onboarding.sol
@@ -125,6 +125,7 @@ contract OnboardingContract is
         );
 
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+        require(bank.dao() == dao, "wrong dao");
         bank.registerPotentialNewInternalToken(unitsToMint);
         bank.registerPotentialNewToken(tokenAddr);
     }
@@ -213,6 +214,7 @@ contract OnboardingContract is
             uint256 unitsRequested = proposal.unitsRequested;
             address applicant = proposal.applicant;
             BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+            require(bank.dao() == dao, "wrong dao");
             require(
                 bank.isInternalToken(unitsToMint),
                 "it can only mint units"

--- a/contracts/adapters/Ragequit.sol
+++ b/contracts/adapters/Ragequit.sol
@@ -79,6 +79,7 @@ contract RagequitContract is IRagequit, DaoConstants, AdapterGuard {
 
         // Instantiates the Bank extension to handle the internal balance checks and transfers.
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+        require(bank.dao() == dao, "wrong dao");
         // Check if member has enough units to burn.
         require(
             bank.balanceOf(memberAddr, UNITS) >= unitsToBurn,

--- a/contracts/adapters/Tribute.sol
+++ b/contracts/adapters/Tribute.sol
@@ -89,6 +89,7 @@ contract TributeContract is
         onlyAdapter(dao)
     {
         BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+        require(bank.dao() == dao, "wrong dao");
         bank.registerPotentialNewInternalToken(tokenAddrToMint);
     }
 
@@ -187,6 +188,7 @@ contract TributeContract is
 
         if (voteResult == IVoting.VotingState.PASS) {
             BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+            require(bank.dao() == dao, "wrong dao");
             address tokenToMint = proposal.tokenToMint;
             address applicant = proposal.applicant;
             uint256 tributeAmount = proposal.tributeAmount;

--- a/contracts/adapters/TributeNFT.sol
+++ b/contracts/adapters/TributeNFT.sol
@@ -168,6 +168,7 @@ contract TributeNFTContract is
         if (voteResult == IVoting.VotingState.PASS) {
             NFTExtension nftExt = NFTExtension(dao.getExtensionAddress(NFT));
             BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+            require(nftExt.dao() == dao, "wrong dao");
             require(bank.dao() == dao, "wrong dao");
             require(
                 bank.isInternalToken(UNITS),

--- a/contracts/adapters/TributeNFT.sol
+++ b/contracts/adapters/TributeNFT.sol
@@ -168,6 +168,7 @@ contract TributeNFTContract is
         if (voteResult == IVoting.VotingState.PASS) {
             NFTExtension nftExt = NFTExtension(dao.getExtensionAddress(NFT));
             BankExtension bank = BankExtension(dao.getExtensionAddress(BANK));
+            require(bank.dao() == dao, "wrong dao");
             require(
                 bank.isInternalToken(UNITS),
                 "UNITS token is not an internal token"


### PR DESCRIPTION
## Proposed Changes

- Since we won't update the extensions for v1, every adapter needs to check if the dao provided in the call arguments matches the extension.dao(), if not, it must revert.

related to #484 (v2)