### PR TITLE
fix: LendNFT and InternalTokenVestingExtension

### DIFF
--- a/contracts/adapters/LendNFT.sol
+++ b/contracts/adapters/LendNFT.sol
@@ -265,6 +265,7 @@ contract LendNFTContract is
             BankExtension bank = BankExtension(
                 dao.getExtensionAddress(DaoHelper.BANK)
             );
+
             bank.subtractFromBalance(
                 dao,
                 proposal.applicant,
@@ -275,7 +276,7 @@ contract LendNFTContract is
                 dao,
                 proposal.applicant,
                 DaoHelper.UNITS,
-                uint64(proposal.lendingPeriod - elapsedTime)
+                uint88(blockedAmount)
             );
         }
 

--- a/contracts/extensions/token/erc20/InternalTokenVestingExtension.sol
+++ b/contracts/extensions/token/erc20/InternalTokenVestingExtension.sol
@@ -118,7 +118,13 @@ contract InternalTokenVestingExtension is IExtension {
         address internalToken,
         uint88 amountToRemove
     ) external hasExtensionAccess(dao, AclFlag.REMOVE_VESTING) {
-        vesting[member][internalToken].blockedAmount -= amountToRemove;
+        VestingSchedule storage schedule = vesting[member][internalToken];
+        uint88 blockedAmount = getMinimumBalanceInternal(schedule.startDate,
+                schedule.endDate,
+                schedule.blockedAmount);
+        
+        schedule.startDate = uint64(block.timestamp);
+        schedule.blockedAmount = blockedAmount - amountToRemove;
     }
 
     /**

--- a/contracts/extensions/token/erc20/InternalTokenVestingExtension.sol
+++ b/contracts/extensions/token/erc20/InternalTokenVestingExtension.sol
@@ -119,10 +119,12 @@ contract InternalTokenVestingExtension is IExtension {
         uint88 amountToRemove
     ) external hasExtensionAccess(dao, AclFlag.REMOVE_VESTING) {
         VestingSchedule storage schedule = vesting[member][internalToken];
-        uint88 blockedAmount = getMinimumBalanceInternal(schedule.startDate,
-                schedule.endDate,
-                schedule.blockedAmount);
-        
+        uint88 blockedAmount = getMinimumBalanceInternal(
+            schedule.startDate,
+            schedule.endDate,
+            schedule.blockedAmount
+        );
+
         schedule.startDate = uint64(block.timestamp);
         schedule.blockedAmount = blockedAmount - amountToRemove;
     }

--- a/test/adapters/lend-nft.test.js
+++ b/test/adapters/lend-nft.test.js
@@ -95,8 +95,8 @@ describe("Adapter - LendNFT", () => {
       nftOwner,
       pixelNFT.address,
       tokenId,
-      10000,
       10000, // requested units
+      10000, // lending period
       [],
       { from: daoOwner, gasPrice: toBN("0") }
     );
@@ -107,8 +107,8 @@ describe("Adapter - LendNFT", () => {
       nftOwner,
       erc1155Token.address,
       tokenId2,
-      10000,
-      10000, // requested units
+      25000, // requested units
+      10000, // lending period
       [],
       { from: daoOwner, gasPrice: toBN("0") }
     );
@@ -169,9 +169,7 @@ describe("Adapter - LendNFT", () => {
     expect(balanceOf.toString()).equal("1");
 
     unitBalance = await bank.balanceOf(nftOwner, UNITS);
-    expect(
-      unitBalance.toString() == "10100" || unitBalance.toString() == "10101"
-    ).equal(true);
+    expect(unitBalance.toString() == "25100").equal(true);
 
     await advanceTime(100);
 
@@ -179,13 +177,22 @@ describe("Adapter - LendNFT", () => {
     await lendNFT.sendNFTBack(dao.address, proposalId2, { from: nftOwner });
     unitBalance = await bank.balanceOf(nftOwner, UNITS);
     expect(
-      unitBalance.toString() === "200" ||
-        unitBalance.toString() === "201" ||
-        unitBalance.toString() === "202"
+      unitBalance.toString() === "350" ||
+        unitBalance.toString() === "351" ||
+        unitBalance.toString() === "352"
     ).equal(true);
 
     const balance = await erc1155Token.balanceOf(nftOwner, tokenId2);
     expect(balance.toString()).equal("1");
+
+    await advanceTime(1000);
+
+    unitBalance = await bank.balanceOf(nftOwner, UNITS);
+    expect(
+      unitBalance.toString() === "350" ||
+        unitBalance.toString() === "351" ||
+        unitBalance.toString() === "352"
+    ).equal(true);
   });
 
   it("should not be possible to send ETH to the adapter via receive function", async () => {

--- a/test/adapters/lend-nft.test.js
+++ b/test/adapters/lend-nft.test.js
@@ -148,11 +148,7 @@ describe("Adapter - LendNFT", () => {
     await lendNFT.sendNFTBack(dao.address, proposalId, { from: nftOwner });
 
     unitBalance = await bank.balanceOf(nftOwner, UNITS);
-    expect(
-      unitBalance.toString() == "100" ||
-        unitBalance.toString() == "101" ||
-        unitBalance.toString() === "202"
-    ).equal(true);
+    expect(toNumber(unitBalance.toString())).to.be.closeTo(100, 2);
 
     await advanceTime(10000);
     //process the second proposal

--- a/test/adapters/lend-nft.test.js
+++ b/test/adapters/lend-nft.test.js
@@ -1,6 +1,7 @@
 // Whole-script strict mode syntax
 "use strict";
 
+const { toNumber } = require("web3-utils");
 /**
 MIT License
 
@@ -169,18 +170,14 @@ describe("Adapter - LendNFT", () => {
     expect(balanceOf.toString()).equal("1");
 
     unitBalance = await bank.balanceOf(nftOwner, UNITS);
-    expect(unitBalance.toString() == "25100").equal(true);
+    expect(toNumber(unitBalance.toString())).to.be.closeTo(25100, 2);
 
     await advanceTime(100);
 
     //after 100 seconds, get the second NFT back
     await lendNFT.sendNFTBack(dao.address, proposalId2, { from: nftOwner });
     unitBalance = await bank.balanceOf(nftOwner, UNITS);
-    expect(
-      unitBalance.toString() === "350" ||
-        unitBalance.toString() === "351" ||
-        unitBalance.toString() === "352"
-    ).equal(true);
+    expect(toNumber(unitBalance.toString())).to.be.closeTo(350, 2);
 
     const balance = await erc1155Token.balanceOf(nftOwner, tokenId2);
     expect(balance.toString()).equal("1");
@@ -188,11 +185,7 @@ describe("Adapter - LendNFT", () => {
     await advanceTime(1000);
 
     unitBalance = await bank.balanceOf(nftOwner, UNITS);
-    expect(
-      unitBalance.toString() === "350" ||
-        unitBalance.toString() === "351" ||
-        unitBalance.toString() === "352"
-    ).equal(true);
+    expect(toNumber(unitBalance.toString())).to.be.closeTo(350, 2);
   });
 
   it("should not be possible to send ETH to the adapter via receive function", async () => {

--- a/test/extensions/vesting.test.js
+++ b/test/extensions/vesting.test.js
@@ -27,6 +27,8 @@ SOFTWARE.
 
 const { UNITS, toBN } = require("../../utils/contract-util");
 
+const { toNumber } = require("web3-utils");
+
 const {
   takeChainSnapshot,
   revertChainSnapshot,
@@ -202,24 +204,20 @@ describe("Extension - Vesting", () => {
 
     minBalance = await vesting.getMinimumBalance(daoOwner, UNITS);
     const minBalanceStr = minBalance.toString();
-    //to manage rounding error
-    expect(minBalanceStr === "150" || minBalanceStr === "151").equal(true);
+
+    expect(toNumber(minBalanceStr)).to.be.closeTo(150, 1);
 
     await advanceTime(halfWay.toNumber());
 
     minBalance = await vesting.getMinimumBalance(daoOwner, UNITS);
-    expect(
-      minBalance.toString() === "75" || minBalance.toString() === "76"
-    ).equal(true);
+    expect(toNumber(minBalance.toString())).to.be.closeTo(75, 1);
 
     await vesting.removeVesting(this.dao.address, daoOwner, UNITS, 50, {
       from: daoOwner,
     });
 
     minBalance = await vesting.getMinimumBalance(daoOwner, UNITS);
-    expect(
-      minBalance.toString() === "50" || minBalance.toString() === "51"
-    ).equal(true);
+    expect(toNumber(minBalance.toString())).to.be.closeTo(25, 1);
   });
 
   it("should not be possible to create a new vesting without the ACL permission", async () => {


### PR DESCRIPTION
## Proposed Changes

- `LendNFT.sol`: fix `sendNFTBack` function which was passing the wrong argument to `bank.subtractFromBalance`
- `InternalTokenVestingExtension.sol`: fix `removeVesting` function which was not taking into account the number of tokens blocked for the proposal. The idea is to reset the vesting mechanism to "now" with a new token amount to be vested, and that is based on the blocked amount minus amount to release.
