### PR TITLE
fix-02: reset grace period if is a tie

### DIFF
--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -372,10 +372,13 @@ contract OffchainVotingContract is
             "result weight too low"
         );
 
+        // check whether the new result changes the outcome
         if (
             vote.gracePeriodStartingTime == 0 ||
-            // check whether the new result changes the outcome
-            vote.nbNo > vote.nbYes != result.nbNo > result.nbYes
+            // changed from yes to no or from no to yes
+            vote.nbNo > vote.nbYes != result.nbNo > result.nbYes ||
+            // changed from tie to yes/no or from yes/no to tie
+            ((vote.nbNo == vote.nbYes) != (result.nbNo == result.nbYes))
         ) {
             vote.gracePeriodStartingTime = uint64(block.timestamp);
         }


### PR DESCRIPTION

If a new vote result is submitted and it changes the result status from PASS to TIE, the grace period is not reset. A TIE should not be treated as the same as a NOT_PASS, otherwise any member can abuse it to deny vote proposals before execution.

## Proposed Changes

- Reset the grace period if the last vote result status is a TIE.
