### PR TITLE
fix-18: return the correct selector

### DIFF
--- a/contracts/extensions/erc1155/ERC1155TokenExtension.sol
+++ b/contracts/extensions/erc1155/ERC1155TokenExtension.sol
@@ -378,7 +378,7 @@ contract ERC1155TokenExtension is IExtension, IERC1155Receiver {
             _saveNft(msg.sender, ids[i], DaoHelper.GUILD, values[i]);
         }
 
-        return this.onERC1155Received.selector;
+        return this.onERC1155BatchReceived.selector;
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

- The function `onERC1155BatchReceived` was returning the wrong function selector. It should be `onERC1155BatchReceived` instead of `onERC1155Received`.