### PR TITLE
Generate random deployment account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ subgraph.yaml
 
 # VS Code file history
 .history
+
+# Generated Deployer Mnemonic/Address
+*.secret

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 require("dotenv").config();
 require("ts-node").register({
   files: true,
@@ -10,6 +11,27 @@ require("hardhat-gas-reporter");
 require("./tasks/deploy");
 require("./signers");
 
+const getMnemonic = () => {
+  // Default to .env mnemonic if supplied.
+  if (process.env.WALLET_MNEMONIC) {
+    return process.env.WALLET_MNEMONIC;
+  }
+
+  let mnemonic = '';
+  try {
+    mnemonic = fs.readFileSync('./deployer-mnemonic.secret').toString().trim();
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw new Error(`Error reading deployer mnemonic: ${err.message}`);
+    }
+  }
+
+  if (!mnemonic) {
+    throw new Error('Supply WALLET_MNEMONIC in .env or use `npm run generateDeployerMnemonic` to create one.');
+  }
+  return mnemonic;
+}
+
 module.exports = {
   // Supported Networks
   networks: {
@@ -18,7 +40,7 @@ module.exports = {
       network_id: 1337,
       chainId: 1337,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC,
+        mnemonic: getMnemonic(),
         count: 10,
       },
       throwOnTransactionFailures: true,
@@ -33,7 +55,7 @@ module.exports = {
       url: "http://127.0.0.1:7545",
       chainId: 1337,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
     },
@@ -45,7 +67,7 @@ module.exports = {
       gas: 2100000,
       gasPrice: 4000000000,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,
@@ -58,7 +80,7 @@ module.exports = {
       gas: 2100000,
       gasPrice: 4000000000,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,
@@ -70,7 +92,7 @@ module.exports = {
       gas: 2100000,
       gasPrice: 4000000000,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,
@@ -83,7 +105,7 @@ module.exports = {
       gas: 2100000,
       gasPrice: 10000000000,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,
@@ -96,7 +118,7 @@ module.exports = {
       gas: 2100000,
       gasPrice: 10000000000,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,
@@ -117,7 +139,7 @@ module.exports = {
       chainId: 1,
       skipDryRun: true,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,
@@ -128,7 +150,7 @@ module.exports = {
       chainId: 1666600000,
       skipDryRun: true,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,
@@ -139,7 +161,7 @@ module.exports = {
       chainId: 137,
       skipDryRun: true,
       accounts: {
-        mnemonic: process.env.WALLET_MNEMONIC || "",
+        mnemonic: getMnemonic() || "",
         count: 10,
       },
       signerId: process.env.SIGNER || undefined,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -22,12 +22,12 @@ const getMnemonic = () => {
     mnemonic = fs.readFileSync('./deployer-mnemonic.secret').toString().trim();
   } catch (err) {
     if (err.code !== 'ENOENT') {
-      throw new Error(`Error reading deployer mnemonic: ${err.message}`);
+      throw new Error(`Error reading deployer mnemonic from file: ${err.message}`);
     }
   }
 
   if (!mnemonic) {
-    throw new Error('Supply WALLET_MNEMONIC in .env or use `npm run generateDeployerMnemonic` to create one.');
+    throw new Error('Supply WALLET_MNEMONIC in .env or use `npm run generateDeployerMnemonic`.');
   }
   return mnemonic;
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "slither": "npm run compile && slither . --ignore-compile --hardhat-artifacts-directory ./build/artifacts --config-file slither.config.json",
     "test": "truffle compile && TEST=true ts-mocha --timeout 2000000 --exit --recursive",
     "truffle-verifier": "truffle run verify",
-    "verify": "truffle compile && ts-node tasks/verify.ts"
+    "verify": "truffle compile && ts-node tasks/verify.ts",
+    "generateDeployerMnemonic": "node ./tasks/generateDeployerMnemonic.js"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/tasks/generateDeployerMnemonic.js
+++ b/tasks/generateDeployerMnemonic.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const ethers = require('ethers');
+require("dotenv").config();
+
+const generateDeployerMnemonic = () => {
+  let mnemonicFromFile = '';
+  try {
+    mnemonicFromFile = fs.readFileSync('./deployer-mnemonic.secret').toString().trim();
+  } catch (err) {
+    // Return if error is something other than mnemonic file not existing.
+    if (err.code !== 'ENOENT') {
+      console.log(`Error reading deployer mnemonic: ${err.message}`);
+      return;
+    }
+  }
+  
+  const mnemonic = process.env.WALLET_MNEMONIC || mnemonicFromFile;
+  if (mnemonic) {
+    const mnemonicFileLocation = process.env.WALLET_MNEMONIC ? './.env' : './deployer-mnemonic.secret';
+    const deployerAddress = ethers.Wallet.fromMnemonic(mnemonic).address;
+    console.log(`Mnemonic already specified in ${mnemonicFileLocation}\nDeployer address: ${deployerAddress}`);
+    return;
+  }
+  
+  const wallet = ethers.Wallet.createRandom();
+  fs.writeFileSync('./deployer-mnemonic.secret', wallet.mnemonic.phrase);
+  fs.writeFileSync('./deployer-address.secret', wallet.address);
+  console.log(`Generated mnemonic at ./deployer-mnemonic.secret\nDeployer address: ${wallet.address}\nFund this address before deploying.`);
+};
+
+generateDeployerMnemonic();

--- a/tasks/generateDeployerMnemonic.js
+++ b/tasks/generateDeployerMnemonic.js
@@ -1,31 +1,30 @@
 const fs = require('fs');
 const ethers = require('ethers');
-require("dotenv").config();
 
 const generateDeployerMnemonic = () => {
-  let mnemonicFromFile = '';
+  const mnemonicFilePath = './deployer-mnemonic.secret';
+  let mnemonic = '';
+
   try {
-    mnemonicFromFile = fs.readFileSync('./deployer-mnemonic.secret').toString().trim();
+    mnemonic = fs.readFileSync(mnemonicFilePath).toString().trim();
   } catch (err) {
     // Return if error is something other than mnemonic file not existing.
     if (err.code !== 'ENOENT') {
-      console.log(`Error reading deployer mnemonic: ${err.message}`);
+      console.log(`Error reading deployer mnemonic from file: ${err.message}`);
       return;
     }
   }
-  
-  const mnemonic = process.env.WALLET_MNEMONIC || mnemonicFromFile;
+
   if (mnemonic) {
-    const mnemonicFileLocation = process.env.WALLET_MNEMONIC ? './.env' : './deployer-mnemonic.secret';
     const deployerAddress = ethers.Wallet.fromMnemonic(mnemonic).address;
-    console.log(`Mnemonic already specified in ${mnemonicFileLocation}\nDeployer address: ${deployerAddress}`);
+    console.log(`Mnemonic already generated at: ${mnemonicFilePath}\nDeployer address: ${deployerAddress}`);
     return;
   }
   
   const wallet = ethers.Wallet.createRandom();
-  fs.writeFileSync('./deployer-mnemonic.secret', wallet.mnemonic.phrase);
-  fs.writeFileSync('./deployer-address.secret', wallet.address);
-  console.log(`Generated mnemonic at ./deployer-mnemonic.secret\nDeployer address: ${wallet.address}\nFund this address before deploying.`);
+  fs.writeFileSync(mnemonicFilePath, wallet.mnemonic.phrase);
+  fs.writeFileSync('./deployer-address.secret', wallet.address); // Write deployer address to file for convenience.
+  console.log(`Generated mnemonic at ./deployer-mnemonic.secret\nDeployer address: ${wallet.address}\nFund this address with ETH before deploying.`);
 };
 
 generateDeployerMnemonic();


### PR DESCRIPTION
Add `generateDeployerMnemonic` as alternative to users supplying WALLET_MNEMONIC. `npm run generateDeployerMnemonic` creates the mnemonic at `deployer-mnemonic.secret`. `getMnemonic` in hardhat.config.js defaults to WALLET_MNEMONIC if it exists.

#506 