### PR TITLE
fix(offchain-voting): remove duplicate checks; set node index to start from 1; tests

### DIFF
--- a/configs/contracts.config.ts
+++ b/configs/contracts.config.ts
@@ -677,7 +677,7 @@ export const contracts: Array<ContractConfig> = [
     version: "1.0.0",
     type: ContractType.Adapter,
     acls: {
-      dao: [],
+      dao: [daoAccessFlagsMap.SUBMIT_PROPOSAL, daoAccessFlagsMap.JAIL_MEMBER],
       extensions: {
         [extensionsIdsMap.BANK_EXT]: [
           bankExtensionAclFlagsMap.ADD_TO_BALANCE,

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -329,16 +329,18 @@ contract OffchainVotingContract is
                 vote.gracePeriodStartingTime +
                     dao.getConfiguration(VotingPeriod) <=
                 block.timestamp,
-            "graceperiod finished"
+            "grace period finished"
         );
 
         require(isActiveMember(dao, reporter), "not active member");
 
-        uint256 membersCount = _ovHelper.checkMemberCount(
-            dao,
-            result.index,
-            vote.snapshot
-        );
+        uint256 membersCount = BankExtension(
+            dao.getExtensionAddress(DaoHelper.BANK)
+        ).getPriorAmount(
+                DaoHelper.TOTAL,
+                DaoHelper.MEMBER_COUNT,
+                vote.snapshot
+            );
 
         _ovHelper.checkBadNodeError(
             dao,

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -334,13 +334,11 @@ contract OffchainVotingContract is
 
         require(isActiveMember(dao, reporter), "not active member");
 
-        uint256 membersCount = BankExtension(
-            dao.getExtensionAddress(DaoHelper.BANK)
-        ).getPriorAmount(
-                DaoHelper.TOTAL,
-                DaoHelper.MEMBER_COUNT,
-                vote.snapshot
-            );
+        uint256 membersCount = _getBank(dao).getPriorAmount(
+            DaoHelper.TOTAL,
+            DaoHelper.MEMBER_COUNT,
+            vote.snapshot
+        );
 
         _ovHelper.checkBadNodeError(
             dao,

--- a/contracts/adapters/voting/OffchainVoting.sol
+++ b/contracts/adapters/voting/OffchainVoting.sol
@@ -183,6 +183,11 @@ contract OffchainVotingContract is
             );
     }
 
+    /**
+     * @notice Forcefully fails a given proposal
+     * @param dao The DAO address
+     * @param proposalId The proposal id to mark as failed
+     */
     // slither-disable-next-line reentrancy-benign
     function adminFailProposal(DaoRegistry dao, bytes32 proposalId)
         external
@@ -593,6 +598,13 @@ contract OffchainVotingContract is
         }
     }
 
+    /**
+     * @notice Enables the fallback voting strategy if the request is valid
+     * @notice Current voting must be in progress
+     * @notice It is not possible to request it more than once for the same member
+     * @param dao The DAO address
+     * @param proposalId The proposalId that will used in the fallback voting contract
+     */
     // slither-disable-next-line reentrancy-benign
     function requestFallback(DaoRegistry dao, bytes32 proposalId)
         external
@@ -626,6 +638,12 @@ contract OffchainVotingContract is
         }
     }
 
+    /**
+     * @notice Starts a new offchain voting proposal
+     * @param dao The DAO address
+     * @param proposalId The new proposal id
+     * @param data The bytes data containing the proposal payload (SnapshotProposalContract.ProposalMessage)
+     */
     // slither-disable-next-line reentrancy-benign
     function startNewVotingForProposal(
         DaoRegistry dao,

--- a/contracts/adapters/voting/OffchainVotingHash.sol
+++ b/contracts/adapters/voting/OffchainVotingHash.sol
@@ -178,8 +178,9 @@ contract OffchainVotingHashContract {
         uint256 snapshot,
         VoteStepParams memory params
     ) external view returns (bool) {
+        require(node.index > 0, "invalid node index");
         address voter = dao.getPriorDelegateKey(
-            dao.getMemberAddress(node.index),
+            dao.getMemberAddress(node.index - 1),
             snapshot
         );
         uint256 weight = GovernanceHelper.getVotingWeight(

--- a/contracts/adapters/voting/OffchainVotingHash.sol
+++ b/contracts/adapters/voting/OffchainVotingHash.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.8.0;
 
 // SPDX-License-Identifier: MIT
-
 import "../../core/DaoRegistry.sol";
 import "../../extensions/bank/Bank.sol";
 import "../../extensions/token/erc20/ERC20TokenExtension.sol";

--- a/contracts/helpers/OffchainVotingHelper.sol
+++ b/contracts/helpers/OffchainVotingHelper.sol
@@ -66,21 +66,6 @@ contract OffchainVotingHelperContract {
         _ovHash = _contract;
     }
 
-    function checkMemberCount(
-        DaoRegistry dao,
-        uint256 resultIndex,
-        uint256 blockNumber
-    ) external view returns (uint256 membersCount) {
-        membersCount = BankExtension(dao.getExtensionAddress(DaoHelper.BANK))
-            .getPriorAmount(
-                DaoHelper.TOTAL,
-                DaoHelper.MEMBER_COUNT,
-                blockNumber
-            );
-        // slither-disable-next-line timestamp
-        require(membersCount - 1 == resultIndex, "index:member_count mismatch");
-    }
-
     function checkBadNodeError(
         DaoRegistry dao,
         bytes32 proposalId,

--- a/contracts/helpers/OffchainVotingHelper.sol
+++ b/contracts/helpers/OffchainVotingHelper.sol
@@ -109,11 +109,11 @@ contract OffchainVotingHelperContract {
             MerkleProof.verify(node.proof, resultRoot, hashCurrent),
             "invalid node proof"
         );
-        if (node.index >= nbMembers) {
+        if (node.index > nbMembers) {
             return BadNodeError.INDEX_OUT_OF_BOUND;
         }
 
-        address memberAddr = dao.getMemberAddress(node.index);
+        address memberAddr = dao.getMemberAddress(node.index - 1);
 
         //invalid choice
         if (

--- a/contracts/helpers/OffchainVotingHelper.sol
+++ b/contracts/helpers/OffchainVotingHelper.sol
@@ -122,7 +122,7 @@ contract OffchainVotingHelperContract {
         //check that the step is indeed part of the result
         require(
             MerkleProof.verify(node.proof, resultRoot, hashCurrent),
-            "proof:bad"
+            "invalid node proof"
         );
         if (node.index >= nbMembers) {
             return BadNodeError.INDEX_OUT_OF_BOUND;

--- a/utils/deployment-util.js
+++ b/utils/deployment-util.js
@@ -431,6 +431,7 @@ const deployDao = async (options) => {
     dao,
     daoFactory,
     extensions,
+    adapters,
   });
 
   // If the offchain contract was created, set it to the adapters map using the alias
@@ -712,12 +713,14 @@ const configureOffchainVoting = async ({
   OffchainVotingHelperContract,
   deployFunction,
   extensions,
+  adapters,
 }) => {
   debug("configuring offchain voting...");
   const votingHelpers = {
     snapshotProposalContract: null,
     handleBadReporterAdapter: null,
     offchainVoting: null,
+    fallbackVoting: null,
   };
 
   // Offchain voting is disabled
@@ -784,6 +787,7 @@ const configureOffchainVoting = async ({
   votingHelpers.offchainVoting = offchainVotingContract;
   votingHelpers.handleBadReporterAdapter = handleBadReporterAdapter;
   votingHelpers.snapshotProposalContract = snapshotProposalContract;
+  votingHelpers.fallbackVoting = adapters.voting;
 
   return votingHelpers;
 };

--- a/utils/hardhat-test-util.js
+++ b/utils/hardhat-test-util.js
@@ -134,7 +134,7 @@ const getDefaultOptions = (options) => {
     unitPrice: unitPrice,
     nbUnits: numberOfUnits,
     votingPeriod: 10,
-    gracePeriod: 1,
+    gracePeriod: 10,
     tokenAddr: ETH_TOKEN,
     maxChunks: maximumChunks,
     maxAmount,

--- a/utils/offchain-voting-util.js
+++ b/utils/offchain-voting-util.js
@@ -456,13 +456,17 @@ async function prepareVoteResult(votes, dao, actionId, chainId) {
   votes.forEach((vote, idx) => {
     const stepIndex = idx + 1;
     vote.choice = vote.choice || vote.payload.choice;
-    vote.nbYes = vote.choice === 1 ? vote.payload.weight : toBNWeb3(0);
-    vote.nbNo = vote.choice !== 1 ? vote.payload.weight : toBNWeb3(0);
+    vote.nbYes = vote.choice === 1 ? vote.payload.weight.toString() : "0";
+    vote.nbNo = vote.choice !== 1 ? vote.payload.weight.toString() : "0";
     vote.proposalId = vote.payload.proposalId;
     if (stepIndex > 1) {
       const previousVote = votes[stepIndex - 1];
-      vote.nbYes = vote.nbYes.add(toBNWeb3(previousVote.nbYes)).toString();
-      vote.nbNo = vote.nbNo.add(toBNWeb3(previousVote.nbNo)).toString();
+      vote.nbYes = toBNWeb3(vote.nbYes)
+        .add(toBNWeb3(previousVote.nbYes))
+        .toString();
+      vote.nbNo = toBNWeb3(vote.nbNo)
+        .add(toBNWeb3(previousVote.nbNo))
+        .toString();
     }
 
     vote.index = stepIndex;

--- a/utils/test-util.js
+++ b/utils/test-util.js
@@ -1,13 +1,26 @@
 // Whole-script strict mode syntax
 "use strict";
-const { toBN, UNITS, ERC1155 } = require("./contract-util");
+const {
+  toBN,
+  TOTAL,
+  MEMBER_COUNT,
+  UNITS,
+  ERC1155,
+} = require("./contract-util");
 const { toNumber } = require("web3-utils");
 const {
   expect,
   advanceTime,
   web3,
+  generateMembers,
   encodeProposalData,
 } = require("./hardhat-test-util");
+
+const {
+  createVote,
+  SigUtilSigner,
+  prepareVoteResult,
+} = require("./offchain-voting-util");
 
 const checkLastEvent = async (dao, testObject) => {
   let pastEvents = await dao.getPastEvents();
@@ -266,6 +279,258 @@ const lendERC1155NFT = async (
   expect(toNumber(unitBalance.toString())).to.be.closeTo(25000, 5);
 };
 
+/***
+ * Offchain Voting Test Utils
+ */
+
+const VotingStrategies = {
+  AllVotesYes: "AllVotesYes",
+  AllVotesNo: "AllVotesNo",
+  NoBodyVotes: "NoBodyVotes",
+  SingleYesVote: "SingleYesVote",
+  SingleNoVote: "SingleNoVote",
+  TieVote: "TieVote",
+  MajorityVotesYes: "MajorityVotesYes",
+  MajorityVotesNo: "MajorityVotesNo",
+};
+
+const testMembers = generateMembers(10);
+
+const findMember = (addr) =>
+  testMembers.find((member) => member.address === addr);
+
+const buildProposal = async (
+  dao,
+  actionId,
+  submitter,
+  blockNumber,
+  chainId,
+  name = "some proposal",
+  body = "this is my proposal",
+  space = "tribute"
+) => {
+  const proposalPayload = {
+    name,
+    body,
+    choices: ["yes", "no"],
+    start: Math.floor(new Date().getTime() / 1000),
+    end: Math.floor(new Date().getTime() / 1000) + 10000,
+    snapshot: blockNumber.toString(),
+  };
+
+  const startingTime = Math.floor(new Date().getTime() / 1000);
+  const proposalData = {
+    type: "proposal",
+    timestamp: startingTime,
+    space,
+    payload: proposalPayload,
+    submitter: submitter.address,
+  };
+
+  const signer = SigUtilSigner(submitter.privateKey);
+  proposalData.sig = await signer(proposalData, dao.address, actionId, chainId);
+  return { proposalData };
+};
+
+const vote = async (
+  dao,
+  bank,
+  proposalId,
+  member,
+  choice,
+  actionId,
+  chainId,
+  votingWeight = undefined,
+  signature = undefined
+) => {
+  const voteSigner = SigUtilSigner(member.privateKey);
+  const weight = await bank.balanceOf(member.address, UNITS);
+  const voteEntry = await createVote(
+    proposalId,
+    votingWeight ? toBN(votingWeight) : weight,
+    choice
+  );
+  voteEntry.sig = signature
+    ? signature
+    : voteSigner(voteEntry, dao.address, actionId, chainId);
+  return voteEntry;
+};
+
+const emptyVote = async (proposalId, choice = 2 /*no*/, signature = "0x") => {
+  const voteEntry = await createVote(proposalId, toBN("0"), choice);
+  voteEntry.sig = signature;
+  return voteEntry;
+};
+
+const buildVotes = async (
+  dao,
+  bank,
+  proposalId,
+  submitter,
+  blockNumber,
+  chainId,
+  actionId,
+  voteStrategy,
+  votingWeight = undefined,
+  voteChoice = undefined,
+  signature = undefined
+) => {
+  const membersCount = await bank.getPriorAmount(
+    TOTAL,
+    MEMBER_COUNT,
+    blockNumber
+  );
+  const voteEntries = [];
+  const totalVotes = parseInt(membersCount.toString());
+  for (let index = 0; index < totalVotes; index++) {
+    const memberAddress = await dao.getMemberAddress(index);
+    const member = findMember(memberAddress);
+    let voteEntry;
+
+    if (!member) {
+      voteEntry = await emptyVote(proposalId, 2, signature);
+      voteEntries.push(voteEntry);
+      continue;
+    }
+
+    switch (voteStrategy) {
+      case VotingStrategies.SingleYesVote &&
+        memberAddress === submitter.address:
+        voteEntry = await vote(
+          dao,
+          bank,
+          proposalId,
+          member,
+          voteChoice ? voteChoice : 1,
+          actionId,
+          chainId,
+          votingWeight,
+          signature
+        );
+        break;
+      case VotingStrategies.SingleNoVote && memberAddress === submitter.address:
+        voteEntry = await vote(
+          dao,
+          bank,
+          proposalId,
+          member,
+          voteChoice ? voteChoice : 2,
+          actionId,
+          chainId,
+          votingWeight,
+          signature
+        );
+        break;
+      case VotingStrategies.AllVotesYes:
+        voteEntry = await vote(
+          dao,
+          bank,
+          proposalId,
+          member,
+          voteChoice ? voteChoice : 1,
+          actionId,
+          chainId,
+          votingWeight,
+          signature
+        );
+        break;
+      case VotingStrategies.AllVotesNo:
+        voteEntry = await vote(
+          dao,
+          bank,
+          proposalId,
+          member,
+          voteChoice ? voteChoice : 2,
+          actionId,
+          chainId,
+          votingWeight,
+          signature
+        );
+        break;
+      case VotingStrategies.TieVote:
+        voteEntry = await vote(
+          dao,
+          bank,
+          proposalId,
+          member,
+          i < parseInt(totalVotes / 2) ? 1 : 2,
+          actionId,
+          chainId,
+          votingWeight,
+          signature
+        );
+        break;
+      case VotingStrategies.NoBodyVotes:
+      default:
+        voteEntry = await emptyVote(proposalId, 2, signature);
+        break;
+    }
+    voteEntries.push(voteEntry);
+  }
+  return voteEntries;
+};
+
+const buildVoteTree = async (
+  dao,
+  bank,
+  proposalId,
+  submitter,
+  blockNumber,
+  chainId,
+  actionId,
+  votingStrategy = VotingStrategies.AllVotesYes,
+  votes = undefined,
+  moveBlockTime = true
+) => {
+  const membersCount = await bank.getPriorAmount(
+    TOTAL,
+    MEMBER_COUNT,
+    blockNumber
+  );
+
+  const voteEntries = votes
+    ? votes
+    : await buildVotes(
+        dao,
+        bank,
+        proposalId,
+        submitter,
+        blockNumber,
+        chainId,
+        actionId,
+        votingStrategy
+      );
+
+  if (moveBlockTime) await advanceTime(10000);
+
+  const { voteResultTree, result } = await prepareVoteResult(
+    voteEntries,
+    dao,
+    actionId,
+    chainId
+  );
+
+  const signer = SigUtilSigner(submitter.privateKey);
+  const rootSig = signer(
+    { root: voteResultTree.getHexRoot(), type: "result" },
+    dao.address,
+    actionId,
+    chainId
+  );
+
+  const lastResult = result[result.length - 1];
+  lastResult.nbYes = lastResult.nbYes.toString();
+  lastResult.nbNo = lastResult.nbNo.toString();
+  return {
+    voteResultTree,
+    votesResults: result,
+    rootSig,
+    lastVoteResult: lastResult,
+    membersCount,
+    resultHash: voteResultTree.getHexRoot(),
+  };
+};
+
 module.exports = {
   checkLastEvent,
   checkBalance,
@@ -278,4 +543,12 @@ module.exports = {
   lendERC1155NFT,
   isMember,
   encodeDaoInfo,
+  testMembers,
+  VotingStrategies,
+  findMember,
+  buildProposal,
+  vote,
+  emptyVote,
+  buildVotes,
+  buildVoteTree,
 };


### PR DESCRIPTION
## Proposed Changes

- Removed `_verifyNode` redundant check from `OffchainVoting.sol`
- Executing the `isReadyToSubmitResult` check for every new vote result
- Removed `checkMemberCount` from `OffchainVotingHelper.sol` and `OffchainVoting.submitResult` because this check is already done via `getBadNodeError.INDEX_OUT_OF_BOUNDS`.
- Fixed `challengeMissingStep` - missing the ACLs to submit the proposals and jail members.
- Improved `revert` messages.
- Refactor to consider the node.index starting from 1 instead of 0.
- Improved the test coverage for the offchain voting contracts.