### PR TITLE
feat: update KycOnboarding to allow for top ups, update Manager to allow for config-only updates

### DIFF
--- a/configs/contracts.config.ts
+++ b/configs/contracts.config.ts
@@ -943,6 +943,7 @@ export const contracts: Array<ContractConfig> = [
         "maxChunks",
         "maxUnits",
         "kycMaxMembers",
+        "kycCanTopUp",
         "kycFundTargetAddress",
         "tokenAddr",
         "unitTokenToMint",

--- a/contracts/adapters/KycOnboarding.sol
+++ b/contracts/adapters/KycOnboarding.sol
@@ -47,6 +47,7 @@ contract KycOnboardingContract is
     event Onboarded(DaoRegistry dao, address member, uint256 units);
     struct Coupon {
         address kycedMember;
+        uint256 memberNonce;
     }
 
     struct OnboardingDetails {
@@ -58,7 +59,7 @@ contract KycOnboardingContract is
         uint160 amount;
     }
 
-    string public constant COUPON_MESSAGE_TYPE = "Message(address kycedMember)";
+    string public constant COUPON_MESSAGE_TYPE = "Message(address kycedMember,uint256 memberNonce)";
     bytes32 public constant COUPON_MESSAGE_TYPEHASH =
         keccak256(abi.encodePacked(COUPON_MESSAGE_TYPE));
 
@@ -71,6 +72,7 @@ contract KycOnboardingContract is
     bytes32 constant MaximumUnits =
         keccak256("kyc-onboarding.maximumTotalUnits");
     bytes32 constant MaxMembers = keccak256("kyc-onboarding.maxMembers");
+    bytes32 constant CanTopUp = keccak256("kyc-onboarding.canTopUp");
     bytes32 constant FundTargetAddress =
         keccak256("kyc-onboarding.fundTargetAddress");
     bytes32 constant TokensToMint = keccak256("kyc-onboarding.tokensToMint");
@@ -80,9 +82,8 @@ contract KycOnboardingContract is
 
     mapping(DaoRegistry => mapping(address => uint256)) public totalUnits;
 
-    // Tracks the hashes of coupons that were redeemed
-    // hashCouponMessage(dao, Coupon(kycedMember)) => bool
-    mapping(bytes32 => bool) public redeemedCoupons;
+    // hashDaoMember(dao, memberAddress) => uint256
+    mapping(bytes32 => uint256) public memberNonces;
 
     constructor(address payable weth) {
         _weth = WETH(weth);
@@ -98,6 +99,7 @@ contract KycOnboardingContract is
      * @param maximumChunks maximum number of chunks allowed
      * @param maxUnits how many internal tokens can be minted
      * @param maxMembers maximum number of members allowed to join
+     * @param canTopUp whether only new members can join or if existing members can onboard more units
      * @param fundTargetAddress multisig address to transfer the money from, set it to address(0) if you dont want to use a multisig
      * @param tokenAddr the token in which the onboarding can take place
      * @param internalTokensToMint the token that will be minted when the member joins the DAO
@@ -110,6 +112,7 @@ contract KycOnboardingContract is
         uint256 maximumChunks,
         uint256 maxUnits,
         uint256 maxMembers,
+        uint256 canTopUp,
         address fundTargetAddress,
         address tokenAddr,
         address internalTokensToMint
@@ -172,6 +175,7 @@ contract KycOnboardingContract is
             _configKey(tokenAddr, TokensToMint),
             internalTokensToMint
         );
+        dao.setConfiguration(_configKey(tokenAddr, CanTopUp), canTopUp);
 
         BankExtension bank = BankExtension(
             dao.getExtensionAddress(DaoHelper.BANK)
@@ -191,23 +195,32 @@ contract KycOnboardingContract is
         returns (bytes32)
     {
         bytes32 message = keccak256(
-            abi.encode(COUPON_MESSAGE_TYPEHASH, coupon.kycedMember)
+            abi.encode(COUPON_MESSAGE_TYPEHASH, coupon.kycedMember, coupon.memberNonce)
         );
 
         return hashMessage(dao, address(this), message);
     }
 
     /**
+     * @notice Builds the key used for memberNonces.
+     */
+    function hashDaoMember(address daoAddress, address daoMember) public pure returns (bytes32) {
+        return keccak256(abi.encode(daoAddress, daoMember));
+    }
+
+    /**
      * @notice Starts the onboarding propocess of a kyc member that is using ETH to join the DAO.
      * @param kycedMember The address of the kyced member that wants to join the DAO.
+     * @param memberNonce The kycedMember's coupon nonce for the specified DAO.
      * @param signature The signature that will be verified to redeem the coupon.
      */
     function onboardEth(
         DaoRegistry dao,
         address kycedMember,
+        uint256 memberNonce,
         bytes memory signature
     ) external payable {
-        _onboard(dao, kycedMember, DaoHelper.ETH_TOKEN, msg.value, signature);
+        _onboard(dao, kycedMember, DaoHelper.ETH_TOKEN, msg.value, memberNonce, signature);
     }
 
     /**
@@ -215,6 +228,7 @@ contract KycOnboardingContract is
      * @param kycedMember The address of the kyced member that wants to join the DAO.
      * @param tokenAddr The address of the ERC20 token that contains that funds of the kycedMember.
      * @param amount The amount in ERC20 that will be contributed to the DAO in exchange for the DAO units.
+     * @param memberNonce The kycedMember's coupon nonce for the specified DAO.
      * @param signature The signature that will be verified to redeem the coupon.
      */
     function onboard(
@@ -222,9 +236,10 @@ contract KycOnboardingContract is
         address kycedMember,
         address tokenAddr,
         uint256 amount,
+        uint256 memberNonce,
         bytes memory signature
     ) external {
-        _onboard(dao, kycedMember, tokenAddr, amount, signature);
+        _onboard(dao, kycedMember, tokenAddr, amount, memberNonce, signature);
     }
 
     /**
@@ -232,6 +247,7 @@ contract KycOnboardingContract is
      * @param dao is the DAO instance to be configured
      * @param kycedMember is the address that this coupon authorized to become a new member
      * @param tokenAddr is the address the ETH address(0) or an ERC20 Token address
+     * @param memberNonce The kycedMember's coupon nonce for the specified DAO
      * @param signature is message signature for verification
      */
     // The function is protected against reentrancy with the reentrancyGuard(dao)
@@ -243,22 +259,25 @@ contract KycOnboardingContract is
         address kycedMember,
         address tokenAddr,
         uint256 amount,
+        uint256 memberNonce,
         bytes memory signature
     ) internal reimbursable(dao) {
         require(
-            !isActiveMember(dao, dao.getCurrentDelegateKey(kycedMember)),
+            !isActiveMember(dao, dao.getCurrentDelegateKey(kycedMember)) ||
+                _daoCanTopUp(dao, tokenAddr),
             "already member"
         );
-        bytes32 couponHash = hashCouponMessage(dao, Coupon(kycedMember));
-        require(!redeemedCoupons[couponHash], "already redeemed");
+        require(memberNonce > memberNonces[hashDaoMember(address(dao), kycedMember)], "already redeemed");
+        memberNonces[hashDaoMember(address(dao), kycedMember)] = memberNonce;
+
         uint256 maxMembers = dao.getConfiguration(
             _configKey(tokenAddr, MaxMembers)
         );
         require(maxMembers > 0, "token not configured");
         require(dao.getNbMembers() < maxMembers, "the DAO is full");
 
+        bytes32 couponHash = hashCouponMessage(dao, Coupon(kycedMember, memberNonce));
         _checkKycCoupon(dao, tokenAddr, couponHash, signature);
-        redeemedCoupons[couponHash] = true;
 
         OnboardingDetails memory details = _checkData(dao, tokenAddr, amount);
         totalUnits[dao][tokenAddr] += details.unitsRequested;
@@ -406,5 +425,12 @@ contract KycOnboardingContract is
         returns (bytes32)
     {
         return keccak256(abi.encode(tokenAddrToMint, key));
+    }
+
+    /**
+     * @notice Returns if a dao allows kyc top ups.
+     */
+    function _daoCanTopUp(DaoRegistry dao, address tokenAddr) internal view returns (bool) {
+        return dao.getConfiguration(_configKey(tokenAddr, CanTopUp)) > 0;
     }
 }

--- a/contracts/adapters/KycOnboarding.sol
+++ b/contracts/adapters/KycOnboarding.sol
@@ -59,7 +59,8 @@ contract KycOnboardingContract is
         uint160 amount;
     }
 
-    string public constant COUPON_MESSAGE_TYPE = "Message(address kycedMember,uint256 memberNonce)";
+    string public constant COUPON_MESSAGE_TYPE =
+        "Message(address kycedMember,uint256 memberNonce)";
     bytes32 public constant COUPON_MESSAGE_TYPEHASH =
         keccak256(abi.encodePacked(COUPON_MESSAGE_TYPE));
 
@@ -195,7 +196,11 @@ contract KycOnboardingContract is
         returns (bytes32)
     {
         bytes32 message = keccak256(
-            abi.encode(COUPON_MESSAGE_TYPEHASH, coupon.kycedMember, coupon.memberNonce)
+            abi.encode(
+                COUPON_MESSAGE_TYPEHASH,
+                coupon.kycedMember,
+                coupon.memberNonce
+            )
         );
 
         return hashMessage(dao, address(this), message);
@@ -204,7 +209,11 @@ contract KycOnboardingContract is
     /**
      * @notice Builds the key used for memberNonces.
      */
-    function hashDaoMember(address daoAddress, address daoMember) public pure returns (bytes32) {
+    function hashDaoMember(address daoAddress, address daoMember)
+        public
+        pure
+        returns (bytes32)
+    {
         return keccak256(abi.encode(daoAddress, daoMember));
     }
 
@@ -220,7 +229,14 @@ contract KycOnboardingContract is
         uint256 memberNonce,
         bytes memory signature
     ) external payable {
-        _onboard(dao, kycedMember, DaoHelper.ETH_TOKEN, msg.value, memberNonce, signature);
+        _onboard(
+            dao,
+            kycedMember,
+            DaoHelper.ETH_TOKEN,
+            msg.value,
+            memberNonce,
+            signature
+        );
     }
 
     /**
@@ -267,7 +283,11 @@ contract KycOnboardingContract is
                 _daoCanTopUp(dao, tokenAddr),
             "already member"
         );
-        require(memberNonce > memberNonces[hashDaoMember(address(dao), kycedMember)], "already redeemed");
+        require(
+            memberNonce >
+                memberNonces[hashDaoMember(address(dao), kycedMember)],
+            "already redeemed"
+        );
         memberNonces[hashDaoMember(address(dao), kycedMember)] = memberNonce;
 
         uint256 maxMembers = dao.getConfiguration(
@@ -276,7 +296,10 @@ contract KycOnboardingContract is
         require(maxMembers > 0, "token not configured");
         require(dao.getNbMembers() < maxMembers, "the DAO is full");
 
-        bytes32 couponHash = hashCouponMessage(dao, Coupon(kycedMember, memberNonce));
+        bytes32 couponHash = hashCouponMessage(
+            dao,
+            Coupon(kycedMember, memberNonce)
+        );
         _checkKycCoupon(dao, tokenAddr, couponHash, signature);
 
         OnboardingDetails memory details = _checkData(dao, tokenAddr, amount);
@@ -430,7 +453,11 @@ contract KycOnboardingContract is
     /**
      * @notice Returns if a dao allows kyc top ups.
      */
-    function _daoCanTopUp(DaoRegistry dao, address tokenAddr) internal view returns (bool) {
+    function _daoCanTopUp(DaoRegistry dao, address tokenAddr)
+        internal
+        view
+        returns (bool)
+    {
         return dao.getConfiguration(_configKey(tokenAddr, CanTopUp)) > 0;
     }
 }

--- a/contracts/adapters/KycOnboarding.sol
+++ b/contracts/adapters/KycOnboarding.sol
@@ -83,8 +83,8 @@ contract KycOnboardingContract is
 
     mapping(DaoRegistry => mapping(address => uint256)) public totalUnits;
 
-    // hashDaoMember(dao, memberAddress) => uint256
-    mapping(bytes32 => uint256) public memberNonces;
+    // memberAddress => uint256
+    mapping(address => uint256) public memberNonces;
 
     constructor(address payable weth) {
         _weth = WETH(weth);
@@ -207,17 +207,6 @@ contract KycOnboardingContract is
     }
 
     /**
-     * @notice Builds the key used for memberNonces.
-     */
-    function hashDaoMember(address daoAddress, address daoMember)
-        public
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encode(daoAddress, daoMember));
-    }
-
-    /**
      * @notice Starts the onboarding propocess of a kyc member that is using ETH to join the DAO.
      * @param kycedMember The address of the kyced member that wants to join the DAO.
      * @param memberNonce The kycedMember's coupon nonce for the specified DAO.
@@ -283,12 +272,8 @@ contract KycOnboardingContract is
                 _daoCanTopUp(dao, tokenAddr),
             "already member"
         );
-        require(
-            memberNonce >
-                memberNonces[hashDaoMember(address(dao), kycedMember)],
-            "already redeemed"
-        );
-        memberNonces[hashDaoMember(address(dao), kycedMember)] = memberNonce;
+        require(memberNonce > memberNonces[kycedMember], "already redeemed");
+        memberNonces[kycedMember] = memberNonce;
 
         uint256 maxMembers = dao.getConfiguration(
             _configKey(tokenAddr, MaxMembers)

--- a/contracts/adapters/Manager.sol
+++ b/contracts/adapters/Manager.sol
@@ -161,10 +161,7 @@ contract Manager is Reimbursable, AdapterGuard, Signatures {
     ) internal reimbursable(dao) {
         dao.submitProposal(proposalId);
         dao.processProposal(proposalId);
-        if (proposal.updateType == UpdateType.CONFIGS) {
-            _saveDaoConfigurations(dao, configs);
-            return;
-        } else if (proposal.updateType == UpdateType.ADAPTER) {
+        if (proposal.updateType == UpdateType.ADAPTER) {
             dao.replaceAdapter(
                 proposal.adapterOrExtensionId,
                 proposal.adapterOrExtensionAddr,
@@ -174,7 +171,7 @@ contract Manager is Reimbursable, AdapterGuard, Signatures {
             );
         } else if (proposal.updateType == UpdateType.EXTENSION) {
             _replaceExtension(dao, proposal);
-        } else {
+        } else if (proposal.updateType != UpdateType.CONFIGS) {
             revert("unknown update type");
         }
         _grantExtensionAccess(dao, proposal);

--- a/contracts/adapters/Manager.sol
+++ b/contracts/adapters/Manager.sol
@@ -37,7 +37,8 @@ contract Manager is Reimbursable, AdapterGuard, Signatures {
     enum UpdateType {
         UNKNOWN,
         ADAPTER,
-        EXTENSION
+        EXTENSION,
+        CONFIGS
     }
 
     enum ConfigType {
@@ -160,7 +161,10 @@ contract Manager is Reimbursable, AdapterGuard, Signatures {
     ) internal reimbursable(dao) {
         dao.submitProposal(proposalId);
         dao.processProposal(proposalId);
-        if (proposal.updateType == UpdateType.ADAPTER) {
+        if (proposal.updateType == UpdateType.CONFIGS) {
+            _saveDaoConfigurations(dao, configs);
+            return;
+        } else if (proposal.updateType == UpdateType.ADAPTER) {
             dao.replaceAdapter(
                 proposal.adapterOrExtensionId,
                 proposal.adapterOrExtensionAddr,

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -724,8 +724,7 @@ const getEnvVar = (name) => {
 };
 
 const getOptionalEnvVar = (name, defaultValue) => {
-  const envVar = process.env[name];
-  if (name == "KYC_CAN_TOP_UP") console.log("KYC_CAN_TOP_UP", envVar);
+  const envVar = process.env[name];  
   return envVar ? envVar : defaultValue;
 };
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -724,7 +724,7 @@ const getEnvVar = (name) => {
 };
 
 const getOptionalEnvVar = (name, defaultValue) => {
-  const envVar = process.env[name];  
+  const envVar = process.env[name];
   return envVar ? envVar : defaultValue;
 };
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -128,7 +128,7 @@ const deployRinkebyDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -186,7 +186,7 @@ const deployMainnetDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getEnvVar("KYC_MAX_MEMBERS"),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -244,7 +244,7 @@ const deployGanacheDao = async ({
     ),
     kycSignerAddress: getOptionalEnvVar("KYC_SIGNER_ADDR", daoOwnerAddress),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -305,7 +305,7 @@ const deployTestDao = async ({
     couponCreatorAddress: daoOwnerAddress,
     kycSignerAddress: daoOwnerAddress,
     kycMaxMembers: toBN("1000"),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -354,7 +354,7 @@ const deployHarmonyDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(99)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -413,7 +413,7 @@ const deployHarmonyTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -468,7 +468,7 @@ const deployPolygonDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getEnvVar("KYC_MAX_MEMBERS"),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -526,7 +526,7 @@ const deployPolygonTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -591,7 +591,7 @@ const deployAvalancheTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -659,7 +659,7 @@ const deployAvalancheDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -128,7 +128,7 @@ const deployRinkebyDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -186,7 +186,7 @@ const deployMainnetDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getEnvVar("KYC_MAX_MEMBERS"),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -244,7 +244,7 @@ const deployGanacheDao = async ({
     ),
     kycSignerAddress: getOptionalEnvVar("KYC_SIGNER_ADDR", daoOwnerAddress),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -305,7 +305,7 @@ const deployTestDao = async ({
     couponCreatorAddress: daoOwnerAddress,
     kycSignerAddress: daoOwnerAddress,
     kycMaxMembers: toBN("1000"),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -354,7 +354,7 @@ const deployHarmonyDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(99)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -413,7 +413,7 @@ const deployHarmonyTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -468,7 +468,7 @@ const deployPolygonDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getEnvVar("KYC_MAX_MEMBERS"),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -526,7 +526,7 @@ const deployPolygonTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -591,7 +591,7 @@ const deployAvalancheTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -659,7 +659,7 @@ const deployAvalancheDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
-    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 1),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -128,6 +128,7 @@ const deployRinkebyDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -185,6 +186,7 @@ const deployMainnetDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getEnvVar("KYC_MAX_MEMBERS"),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -242,6 +244,7 @@ const deployGanacheDao = async ({
     ),
     kycSignerAddress: getOptionalEnvVar("KYC_SIGNER_ADDR", daoOwnerAddress),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -302,6 +305,7 @@ const deployTestDao = async ({
     couponCreatorAddress: daoOwnerAddress,
     kycSignerAddress: daoOwnerAddress,
     kycMaxMembers: toBN("1000"),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -350,6 +354,7 @@ const deployHarmonyDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(99)),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -408,6 +413,7 @@ const deployHarmonyTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -462,6 +468,7 @@ const deployPolygonDao = async ({
     couponCreatorAddress: getEnvVar("COUPON_CREATOR_ADDR"),
     kycSignerAddress: getEnvVar("KYC_SIGNER_ADDR"),
     kycMaxMembers: getEnvVar("KYC_MAX_MEMBERS"),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -519,6 +526,7 @@ const deployPolygonTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -583,6 +591,7 @@ const deployAvalancheTestDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -650,6 +659,7 @@ const deployAvalancheDao = async ({
       getEnvVar("DAO_OWNER_ADDR")
     ),
     kycMaxMembers: getOptionalEnvVar("KYC_MAX_MEMBERS", toBN(1000)),
+    kycCanTopUp: getOptionalEnvVar("KYC_CAN_TOP_UP", 0),
     kycFundTargetAddress: getOptionalEnvVar(
       "KYC_MULTISIG_FUND_ADDR",
       ZERO_ADDRESS
@@ -715,6 +725,7 @@ const getEnvVar = (name) => {
 
 const getOptionalEnvVar = (name, defaultValue) => {
   const envVar = process.env[name];
+  if (name == "KYC_CAN_TOP_UP") console.log("KYC_CAN_TOP_UP", envVar);
   return envVar ? envVar : defaultValue;
 };
 

--- a/test/adapters/kyc-onboarding.test.js
+++ b/test/adapters/kyc-onboarding.test.js
@@ -26,6 +26,7 @@ SOFTWARE.
  */
 const { expect } = require("chai");
 const {
+  sha3,
   toBN,
   toWei,
   unitPrice,
@@ -55,6 +56,12 @@ const {
 const signer = {
   address: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
   privKey: "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d",
+};
+
+const getCanTopUp = (dao) => {
+    const encoder = new ethers.utils.AbiCoder();
+    const key = sha3(encoder.encode(['address','bytes32'], [ETH_TOKEN, sha3("kyc-onboarding.canTopUp")]));
+    return dao.getConfiguration(key);
 };
 
 describe("Adapter - KYC Onboarding", () => {
@@ -497,6 +504,9 @@ describe("Adapter - KYC Onboarding", () => {
       }
     );
 
+    const canTopUp = await getCanTopUp(dao);
+    expect(canTopUp.toNumber()).to.equal(0); // canTopUp is false.
+
     const applicantIsActiveMember = await isMember(bank, applicant);
     expect(applicantIsActiveMember).equal(true);
   })
@@ -541,6 +551,9 @@ describe("Adapter - KYC Onboarding", () => {
       }
     );
 
+    const canTopUp = await getCanTopUp(dao);
+    expect(canTopUp.toNumber()).to.equal(1); // canTopUp is true.
+
     const applicantIsActiveMember = await isMember(bank, applicant);
     expect(applicantIsActiveMember).equal(true);
   });
@@ -584,6 +597,9 @@ describe("Adapter - KYC Onboarding", () => {
         gasPrice: toBN("0"),
       }
     );
+
+    const canTopUp = await getCanTopUp(dao);
+    expect(canTopUp.toNumber()).to.equal(1); // canTopUp is true.
 
     let applicantUnits = await bank.balanceOf(applicant, UNITS);
     expect(applicantUnits.toString()).equal(

--- a/test/adapters/kyc-onboarding.test.js
+++ b/test/adapters/kyc-onboarding.test.js
@@ -99,7 +99,8 @@ describe("Adapter - KYC Onboarding", () => {
     });
 
     const onboarding = adapters.kycOnboarding;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
 
     const initialTokenBalance = await getBalance(applicant);
 
@@ -132,7 +133,8 @@ describe("Adapter - KYC Onboarding", () => {
 
     const bank = extensions.bankExt;
     const onboarding = adapters.kycOnboarding;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
 
     const signerUtil = SigUtilSigner(signer.privKey);
 
@@ -213,7 +215,8 @@ describe("Adapter - KYC Onboarding", () => {
     const dao = this.dao;
     const bank = this.extensions.bankExt;
     const onboarding = this.adapters.kycOnboarding;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
 
     const myAccountInitialBalance = await getBalance(applicant);
     // remaining amount to test sending back to proposer
@@ -243,11 +246,17 @@ describe("Adapter - KYC Onboarding", () => {
       chainId
     );
 
-    await onboarding.onboardEth(dao.address, applicant, memberNonce, signature, {
-      from: applicant,
-      value: ethAmount,
-      gasPrice: toBN("0"),
-    });
+    await onboarding.onboardEth(
+      dao.address,
+      applicant,
+      memberNonce,
+      signature,
+      {
+        from: applicant,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }
+    );
 
     // test return of remaining amount in excess of multiple of unitsPerChunk
     const myAccountBalance = await getBalance(applicant);
@@ -286,7 +295,8 @@ describe("Adapter - KYC Onboarding", () => {
     const dao = this.dao;
     const onboarding = this.adapters.kycOnboarding;
     const daoRegistryAdapter = this.adapters.daoRegistryAdapter;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
 
     const myAccountInitialBalance = await getBalance(applicant);
     // remaining amount to test sending back to proposer
@@ -316,11 +326,17 @@ describe("Adapter - KYC Onboarding", () => {
       chainId
     );
 
-    await onboarding.onboardEth(dao.address, applicant, memberNonce, signature, {
-      from: applicant,
-      value: ethAmount,
-      gasPrice: toBN("0"),
-    });
+    await onboarding.onboardEth(
+      dao.address,
+      applicant,
+      memberNonce,
+      signature,
+      {
+        from: applicant,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }
+    );
 
     // test return of remaining amount in excess of multiple of unitsPerChunk
     const myAccountBalance = await getBalance(applicant);
@@ -347,7 +363,8 @@ describe("Adapter - KYC Onboarding", () => {
     const applicant = accounts[2];
     const dao = this.dao;
     const onboarding = this.adapters.kycOnboarding;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
 
     const signerUtil = SigUtilSigner(signer.privKey);
 
@@ -380,7 +397,8 @@ describe("Adapter - KYC Onboarding", () => {
     const bank = this.extensions.bankExt;
     const onboarding = this.adapters.kycOnboarding;
     const ragequit = this.adapters.ragequit;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
 
     // remaining amount to test sending back to proposer
     const ethAmount = unitPrice.mul(toBN(3)).add(remaining);
@@ -409,11 +427,17 @@ describe("Adapter - KYC Onboarding", () => {
       chainId
     );
 
-    await onboarding.onboardEth(dao.address, applicant, memberNonce, signature, {
-      from: applicant,
-      value: ethAmount,
-      gasPrice: toBN("0"),
-    });
+    await onboarding.onboardEth(
+      dao.address,
+      applicant,
+      memberNonce,
+      signature,
+      {
+        from: applicant,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }
+    );
 
     // test active member status
     expect(await isMember(bank, applicant)).equal(true);
@@ -448,7 +472,8 @@ describe("Adapter - KYC Onboarding", () => {
     const applicant = accounts[2];
     const onboarding = adapters.kycOnboarding;
     const bank = extensions.bankExt;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
     const ethAmount = unitPrice.mul(toBN(3)).add(remaining);
     const signerUtil = SigUtilSigner(signer.privKey);
 
@@ -465,11 +490,17 @@ describe("Adapter - KYC Onboarding", () => {
       chainId
     );
 
-    await onboarding.onboardEth(dao.address, applicant, memberNonce, signature, {
-      from: applicant,
-      value: ethAmount,
-      gasPrice: toBN("0"),
-    });
+    await onboarding.onboardEth(
+      dao.address,
+      applicant,
+      memberNonce,
+      signature,
+      {
+        from: applicant,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }
+    );
 
     const applicantIsActiveMember = await isMember(bank, applicant);
     expect(applicantIsActiveMember).equal(true);
@@ -485,7 +516,8 @@ describe("Adapter - KYC Onboarding", () => {
     const applicant = accounts[2];
     const onboarding = adapters.kycOnboarding;
     const bank = extensions.bankExt;
-    const memberNonce = (await onboarding.memberNonces(applicant)).toNumber() + 1;
+    const memberNonce =
+      (await onboarding.memberNonces(applicant)).toNumber() + 1;
     const ethAmount = unitPrice.mul(toBN(3)).add(remaining);
     const signerUtil = SigUtilSigner(signer.privKey);
 
@@ -502,11 +534,17 @@ describe("Adapter - KYC Onboarding", () => {
       chainId
     );
 
-    await onboarding.onboardEth(dao.address, applicant, memberNonce, signature, {
-      from: applicant,
-      value: ethAmount,
-      gasPrice: toBN("0"),
-    });
+    await onboarding.onboardEth(
+      dao.address,
+      applicant,
+      memberNonce,
+      signature,
+      {
+        from: applicant,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }
+    );
 
     let applicantUnits = await bank.balanceOf(applicant, UNITS);
     expect(applicantUnits.toString()).equal(
@@ -526,11 +564,17 @@ describe("Adapter - KYC Onboarding", () => {
       chainId
     );
 
-    await onboarding.onboardEth(dao.address, applicant, memberNonce + 1, signature2, {
-      from: applicant,
-      value: ethAmount,
-      gasPrice: toBN("0"),
-    });
+    await onboarding.onboardEth(
+      dao.address,
+      applicant,
+      memberNonce + 1,
+      signature2,
+      {
+        from: applicant,
+        value: ethAmount,
+        gasPrice: toBN("0"),
+      }
+    );
 
     applicantUnits = await bank.balanceOf(applicant, UNITS);
     expect(applicantUnits.toString()).equal(

--- a/test/adapters/kyc-onboarding.test.js
+++ b/test/adapters/kyc-onboarding.test.js
@@ -703,8 +703,5 @@ describe("Adapter - KYC Onboarding", () => {
         }
       )
     ).to.be.revertedWith("invalid sig");
-
-    // const applicantIsActiveMember = await isMember(bank, applicant);
-    // expect(applicantIsActiveMember).equal(true);
   });
 });

--- a/test/adapters/kyc-onboarding.test.js
+++ b/test/adapters/kyc-onboarding.test.js
@@ -59,9 +59,14 @@ const signer = {
 };
 
 const getCanTopUp = (dao) => {
-    const encoder = new ethers.utils.AbiCoder();
-    const key = sha3(encoder.encode(['address','bytes32'], [ETH_TOKEN, sha3("kyc-onboarding.canTopUp")]));
-    return dao.getConfiguration(key);
+  const encoder = new ethers.utils.AbiCoder();
+  const key = sha3(
+    encoder.encode(
+      ["address", "bytes32"],
+      [ETH_TOKEN, sha3("kyc-onboarding.canTopUp")]
+    )
+  );
+  return dao.getConfiguration(key);
 };
 
 describe("Adapter - KYC Onboarding", () => {
@@ -509,7 +514,7 @@ describe("Adapter - KYC Onboarding", () => {
 
     const applicantIsActiveMember = await isMember(bank, applicant);
     expect(applicantIsActiveMember).equal(true);
-  })
+  });
 
   it("should be possible to first join when configured with canTopUp", async () => {
     const { dao, adapters, extensions } = await deployDefaultDao({
@@ -677,29 +682,27 @@ describe("Adapter - KYC Onboarding", () => {
       }
     );
 
-    await expect(onboarding.onboardEth(
-      dao.address,
-      applicant,
-      memberNonce,
-      signature,
-      {
+    await expect(
+      onboarding.onboardEth(dao.address, applicant, memberNonce, signature, {
         from: applicant,
         value: ethAmount,
         gasPrice: toBN("0"),
-      }
-    )).to.be.revertedWith("already redeemed");
+      })
+    ).to.be.revertedWith("already redeemed");
 
-    await expect(onboarding.onboardEth(
-      dao.address,
-      applicant,
-      memberNonce + 1,
-      signature,
-      {
-        from: applicant,
-        value: ethAmount,
-        gasPrice: toBN("0"),
-      }
-    )).to.be.revertedWith("invalid sig");
+    await expect(
+      onboarding.onboardEth(
+        dao.address,
+        applicant,
+        memberNonce + 1,
+        signature,
+        {
+          from: applicant,
+          value: ethAmount,
+          gasPrice: toBN("0"),
+        }
+      )
+    ).to.be.revertedWith("invalid sig");
 
     // const applicantIsActiveMember = await isMember(bank, applicant);
     // expect(applicantIsActiveMember).equal(true);

--- a/test/adapters/manager.test.js
+++ b/test/adapters/manager.test.js
@@ -1174,7 +1174,10 @@ describe("Adapter - Manager", () => {
 
     const coder = new ethers.utils.AbiCoder();
     const keyToUpdate = sha3(
-      coder.encode(["address", "bytes32"], [ETH_TOKEN, sha3('kyc-onboarding.maxMembers')])
+      coder.encode(
+        ["address", "bytes32"],
+        [ETH_TOKEN, sha3("kyc-onboarding.maxMembers")]
+      )
     );
     const previousConfigValue = await dao.getConfiguration(keyToUpdate);
 

--- a/test/adapters/manager.test.js
+++ b/test/adapters/manager.test.js
@@ -33,6 +33,7 @@ const {
   GUILD,
   ZERO_ADDRESS,
   DAI_TOKEN,
+  ETH_TOKEN,
 } = require("../../utils/contract-util");
 
 const {
@@ -1151,5 +1152,63 @@ describe("Adapter - Manager", () => {
         signature
       )
     ).to.be.revertedWith("unknown update type");
+  });
+
+  it("should be possible to update only DAO configs with UpdateType.configs", async () => {
+    const dao = this.dao;
+    const proposalId = getProposalCounter();
+    const manager = this.adapters.manager;
+    const kycOnboarding = this.adapters.kycOnboarding;
+    const kycAdapterId = sha3("kyc-onboarding");
+    const nonce = (await manager.nonces(dao.address)).toNumber() + 1;
+    const proposal = {
+      adapterOrExtensionId: kycAdapterId,
+      adapterOrExtensionAddr: kycOnboarding.address,
+      updateType: 3, // UpdateType 3 = configs
+      flags: 0,
+      keys: [],
+      values: [],
+      extensionAddresses: [],
+      extensionAclFlags: [],
+    };
+
+    const coder = new ethers.utils.AbiCoder();
+    const keyToUpdate = sha3(
+      coder.encode(["address", "bytes32"], [ETH_TOKEN, sha3('kyc-onboarding.maxMembers')])
+    );
+    const previousConfigValue = await dao.getConfiguration(keyToUpdate);
+
+    const configs = [
+      {
+        key: keyToUpdate,
+        numericValue: 9000,
+        addressValue: ZERO_ADDRESS,
+        configType: 0, //NUMERIC
+      },
+    ];
+    const signature = generateCouponSignature({
+      daoAddress: dao.address,
+      managerAddress: manager.address,
+      chainId,
+      proposal,
+      configs,
+      nonce,
+      proposalId,
+    });
+
+    await manager.processSignedProposal(
+      dao.address,
+      proposalId,
+      proposal,
+      configs,
+      nonce,
+      signature
+    );
+
+    expect(previousConfigValue).equal("1000");
+    expect(await dao.getConfiguration(keyToUpdate)).equal("9000");
+    expect(await dao.getAdapterAddress(kycAdapterId)).equal(
+      kycOnboarding.address
+    );
   });
 });

--- a/test/adapters/manager.test.js
+++ b/test/adapters/manager.test.js
@@ -1215,14 +1215,14 @@ describe("Adapter - Manager", () => {
     );
   });
 
-  it('should be possible to update extension access with UpdateType.CONFIGS', async () => {
+  it("should be possible to update extension access with UpdateType.CONFIGS", async () => {
     const dao = this.dao;
     const proposalId = getProposalCounter();
     const manager = this.adapters.manager;
     const bankExt = this.extensions.bankExt;
     const nonce = (await manager.nonces(dao.address)).toNumber() + 1;
     const proposal = {
-      adapterOrExtensionId: sha3('manager'),
+      adapterOrExtensionId: sha3("manager"),
       adapterOrExtensionAddr: manager.address,
       updateType: 3, // UpdateType 3 = configs
       flags: 0,

--- a/utils/deployment-util.js
+++ b/utils/deployment-util.js
@@ -567,7 +567,7 @@ const configureDao = async ({
       }
       // 2nd lookup for configs in the options object
       const configValue = options[configName];
-      if (!configValue)
+      if (configValue == null)
         throw new Error(
           `Error while configuring dao parameter [${configName}] for ${contractName}. Config not found.`
         );

--- a/utils/hardhat-test-util.js
+++ b/utils/hardhat-test-util.js
@@ -144,6 +144,7 @@ const getDefaultOptions = (options) => {
     managerSignerAddress: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
     couponCreatorAddress: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
     kycMaxMembers: 1000,
+    kycCanTopUp: 0,
     kycSignerAddress: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
     kycFundTargetAddress: "0x823A19521A76f80EC49670BE32950900E8Cd0ED3",
     deployTestTokens: true,

--- a/utils/offchain-voting-util.js
+++ b/utils/offchain-voting-util.js
@@ -128,7 +128,7 @@ function getCouponKycDomainDefinition(verifyingContract, actionId, chainId) {
   const types = {
     Message: [
       { name: "kycedMember", type: "address" },
-      { name: "memberNonce", type: "uint256" }
+      { name: "memberNonce", type: "uint256" },
     ],
     EIP712Domain: getDomainType(),
   };

--- a/utils/offchain-voting-util.js
+++ b/utils/offchain-voting-util.js
@@ -126,7 +126,10 @@ function getCouponKycDomainDefinition(verifyingContract, actionId, chainId) {
   const domain = getMessageDomainType(chainId, verifyingContract, actionId);
 
   const types = {
-    Message: [{ name: "kycedMember", type: "address" }],
+    Message: [
+      { name: "kycedMember", type: "address" },
+      { name: "memberNonce", type: "uint256" }
+    ],
     EIP712Domain: getDomainType(),
   };
 


### PR DESCRIPTION
#### KycOnboarding.sol changes:
- Adds canTopUp configuration. 
- New environment variable: `KYC_CAN_TOP_UP`, 0 or 1
- Coupon message updated to include memberNonce. Now using memberNonces mapping (address => uint256) instead of redeemedCoupons to prevent replays.

#### Manager.sol changes:
- UpdateType.CONFIGS added to allow for config only updates.
