### PR TITLE
fix: setting standard contracts to be auto deployed

### DIFF
--- a/configs/networks/goerli.config.ts
+++ b/configs/networks/goerli.config.ts
@@ -17,6 +17,7 @@ const disabled: Array<string> = [
   "WETH",
   "ProxTokenContract",
   "ERC20MinterContract",
+  // Adapters, Extensions and Factories disabled by default
   "NFTCollectionFactory",
   "InternalTokenVestingExtensionFactory",
   "ERC1271ExtensionFactory",
@@ -33,7 +34,7 @@ const disabled: Array<string> = [
   "TributeContract",
   "TributeNFTContract",
   "LendNFTContract",
-  "ERC20TransferStrategy"
+  "ERC20TransferStrategy",
 ];
 
 export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {

--- a/configs/networks/goerli.config.ts
+++ b/configs/networks/goerli.config.ts
@@ -13,6 +13,27 @@ const disabled: Array<string> = [
   "ProxToken",
   "ERC20Minter",
   "MockDao",
+  "Multicall",
+  "WETH",
+  "ProxTokenContract",
+  "ERC20MinterContract",
+  "NFTCollectionFactory",
+  "InternalTokenVestingExtensionFactory",
+  "ERC1271ExtensionFactory",
+  "ExecutorExtensionFactory",
+  "ERC1155TokenCollectionFactory",
+  "NFTExtension",
+  "InternalTokenVestingExtension",
+  "ERC1271Extension",
+  "ExecutorExtension",
+  "ERC1155TokenExtension",
+  "ERC1155AdapterContract",
+  "FinancingContract",
+  "OnboardingContract",
+  "TributeContract",
+  "TributeNFTContract",
+  "LendNFTContract",
+  "ERC20TransferStrategy"
 ];
 
 export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {

--- a/configs/networks/mainnet.config.ts
+++ b/configs/networks/mainnet.config.ts
@@ -13,12 +13,28 @@ const disabled: Array<String> = [
   "ProxToken",
   "ERC20Minter",
   "MockDao",
-  // Adapters disabled for Muse0 DAO Deployment
-  "RagequitContract",
+  "Multicall",
+  "WETH",
+  "ProxTokenContract",
+  "ERC20MinterContract",
+  // Adapters, Extensions and Factories disabled by default
+  "NFTCollectionFactory",
+  "InternalTokenVestingExtensionFactory",
+  "ERC1271ExtensionFactory",
+  "ExecutorExtensionFactory",
+  "ERC1155TokenCollectionFactory",
+  "NFTExtension",
+  "InternalTokenVestingExtension",
+  "ERC1271Extension",
+  "ExecutorExtension",
+  "ERC1155TokenExtension",
+  "ERC1155AdapterContract",
   "FinancingContract",
   "OnboardingContract",
   "TributeContract",
-  "DistributeContract",
+  "TributeNFTContract",
+  "LendNFTContract",
+  "ERC20TransferStrategy",
 ];
 
 export const contracts: Array<ContractConfig> = defaultContracts.map((c) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "ethereum-waffle": "^3.4.0",
         "ethereumjs-util": "^7.0.5",
         "ethers": "^5.5.4",
-        "ethers-gcp-kms-signer": "1.1.4",
+        "ethers-gcp-kms-signer": "1.1.5",
         "ganache-cli": "^6.12.2",
         "hardhat": "2.8.2",
         "hardhat-contract-sizer": "^2.4.0",
@@ -16785,9 +16785,9 @@
       }
     },
     "node_modules/ethers-gcp-kms-signer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ethers-gcp-kms-signer/-/ethers-gcp-kms-signer-1.1.4.tgz",
-      "integrity": "sha512-LPGheecClOt/oKM0w6abyYLfWwVEnzIGplIqDlwyuLudbBYMftmneEvLTBQoNf2V/E0dOkLPCh9GIxLAxuLJXw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ethers-gcp-kms-signer/-/ethers-gcp-kms-signer-1.1.5.tgz",
+      "integrity": "sha512-RbjO4l4Aoipl8ob0E8Y9JK8IAgh2zfhvEKknXiCP1VRmLbaUUi0eXpInk9wtGHRbH95N5u7X2HQb64VzuHMIYQ==",
       "dev": true,
       "dependencies": {
         "@google-cloud/kms": "3.0.1",
@@ -61841,9 +61841,9 @@
       }
     },
     "ethers-gcp-kms-signer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ethers-gcp-kms-signer/-/ethers-gcp-kms-signer-1.1.4.tgz",
-      "integrity": "sha512-LPGheecClOt/oKM0w6abyYLfWwVEnzIGplIqDlwyuLudbBYMftmneEvLTBQoNf2V/E0dOkLPCh9GIxLAxuLJXw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ethers-gcp-kms-signer/-/ethers-gcp-kms-signer-1.1.5.tgz",
+      "integrity": "sha512-RbjO4l4Aoipl8ob0E8Y9JK8IAgh2zfhvEKknXiCP1VRmLbaUUi0eXpInk9wtGHRbH95N5u7X2HQb64VzuHMIYQ==",
       "dev": true,
       "requires": {
         "@google-cloud/kms": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethereumjs-util": "^7.0.5",
     "ethers": "^5.5.4",
-    "ethers-gcp-kms-signer": "1.1.4",
+    "ethers-gcp-kms-signer": "1.1.5",
     "ganache-cli": "^6.12.2",
     "hardhat": "2.8.2",
     "hardhat-contract-sizer": "^2.4.0",

--- a/signers/GcpKmsSignerProvider.ts
+++ b/signers/GcpKmsSignerProvider.ts
@@ -9,7 +9,7 @@ import {
   EIP1193Provider,
   RequestArguments,
 } from "hardhat/types";
-import { BigNumber, ethers } from "ethers";
+import { ethers } from "ethers";
 import { numberToHex } from "web3-utils";
 import { GcpKmsSigner } from "ethers-gcp-kms-signer";
 import {


### PR DESCRIPTION
## Proposed Changes

- Disabled utility, adapter, extension, and factory contracts that don't need to be auto-deployed (Goerli & Mainnet)
- Bump `ethers-gcp-kms-signer` to `v1.1.5` to enable credentials via env vars
