### PR TITLE
Vesting Extension enabled in mainnet cfg

### DIFF
--- a/configs/networks/goerli.config.ts
+++ b/configs/networks/goerli.config.ts
@@ -19,12 +19,10 @@ const disabled: Array<string> = [
   "ERC20MinterContract",
   // Adapters, Extensions and Factories disabled by default
   "NFTCollectionFactory",
-  "InternalTokenVestingExtensionFactory",
   "ERC1271ExtensionFactory",
   "ExecutorExtensionFactory",
   "ERC1155TokenCollectionFactory",
   "NFTExtension",
-  "InternalTokenVestingExtension",
   "ERC1271Extension",
   "ExecutorExtension",
   "ERC1155TokenExtension",

--- a/configs/networks/mainnet.config.ts
+++ b/configs/networks/mainnet.config.ts
@@ -19,12 +19,10 @@ const disabled: Array<String> = [
   "ERC20MinterContract",
   // Adapters, Extensions and Factories disabled by default
   "NFTCollectionFactory",
-  "InternalTokenVestingExtensionFactory",
   "ERC1271ExtensionFactory",
   "ExecutorExtensionFactory",
   "ERC1155TokenCollectionFactory",
   "NFTExtension",
-  "InternalTokenVestingExtension",
   "ERC1271Extension",
   "ExecutorExtension",
   "ERC1155TokenExtension",


### PR DESCRIPTION
## Proposed Changes

- `InternalTokenVestingExtension` is used by the ERC20 transfer strategy so we need to enable the extension and factory as part of the mainnet+gorli deployment configuration files.
