### PR TITLE
fix(deploy): log the blockNumber

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -12,6 +12,7 @@ const {
   numberOfUnits,
   maxAmount,
   maxUnits,
+  waitTx,
 } = require("../utils/contract-util");
 const pkgJson = require("../package.json");
 const { deployDao } = require("../utils/deployment-util");
@@ -55,8 +56,6 @@ task("deploy", "Deploy the list of contracts", async (args, hre) => {
     accounts,
   });
 
-  info(`\n Deployment completed with success.\n`);
-
   const {
     dao,
     factories,
@@ -68,7 +67,11 @@ task("deploy", "Deploy the list of contracts", async (args, hre) => {
   } = result;
 
   if (dao) {
-    await dao.finalizeDao();
+    info(`\n Finalize DAO creation...\n`);
+    const tx = await waitTx(dao.finalizeDao());
+    info(`\n DAO finalized @ blockNumber: ${tx.blockNumber}\n`);
+
+    info(`\n Deployment completed with success.\n`);
     const addresses = {
       // The addresses of all identity contracts
       identities: {


### PR DESCRIPTION
## Proposed Changes

- Updated the deployment logs to print out the block number of the `dao.finalizeDao` call. Useful for services that will index the DAO activity.


Sample output:
```
[job-e6df4069-dada-4b4f-8480-3fc7d8811892]  Finalize DAO creation...
[job-e6df4069-dada-4b4f-8480-3fc7d8811892] 
[job-e6df4069-dada-4b4f-8480-3fc7d8811892]       waiting for transaction to be submitted / mined
[job-e6df4069-dada-4b4f-8480-3fc7d8811892]       submitted! tx hash:0x3e4aac51937c5be0a93f97e38df84d8bb06ecf1c66d39e8c558d6585681c874b - nonce:1572
[job-e6df4069-dada-4b4f-8480-3fc7d8811892]       transaction mined
[job-e6df4069-dada-4b4f-8480-3fc7d8811892] 
[job-e6df4069-dada-4b4f-8480-3fc7d8811892]  DAO finalized @ blockNumber: 1573
```
