### PR TITLE
feat: add polygonscan to truffle-verify config

### DIFF
--- a/tasks/verify.ts
+++ b/tasks/verify.ts
@@ -30,9 +30,9 @@ const skipContracts = [
 
 const args = process.argv.slice(2);
 if (!args || args.length === 0)
-  throw Error("Missing one of the network names: [goerli, mainnet]");
+  throw Error("Missing one of the network names: [polygon, mainnet]");
 
-const network = args[0] || "goerli";
+const network = args[0] || "polygon";
 log(`Selected Network: ${network}`);
 
 const sleep = (msec: number) => {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -93,8 +93,10 @@ module.exports = {
       },
     },
   },
+  // Supported chains: https://github.com/rkalis/truffle-plugin-verify?tab=readme-ov-file#supported-chains
   api_keys: {
     etherscan: process.env.ETHERSCAN_API_KEY, // Obtain one at https://etherscan.io/myapikey
+    polygonscan: process.env.POLYGONSCAN_API_KEY, // Obtain one at https://polygonscan.com/myapikey
   },
   plugins: ["truffle-plugin-verify"],
 };


### PR DESCRIPTION
## Proposed Changes

- In order to verify contracts on the Polygon PoS network we need to add the network to the truffle-verify plugin configs.
